### PR TITLE
Fix tab selection sync when tabs are deleted

### DIFF
--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -21,7 +21,7 @@ interface BackgroundMessage {
 
 const Manager = () => {
   const { tabGroups, updateTabGroups } = useTabGroupContext();
-  const { clearSelection, syncWithExistingTabs } = useTabSelectionContext(); // Get clearSelection and syncWithExistingTabs from context
+  const { clearSelection, syncWithExistingTabs } = useTabSelectionContext();
   const [activeWindowId, setActiveWindowId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [sequenceActive, setSequenceActive] = useState<boolean>(false);

--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -21,7 +21,7 @@ interface BackgroundMessage {
 
 const Manager = () => {
   const { tabGroups, updateTabGroups } = useTabGroupContext();
-  const { clearSelection } = useTabSelectionContext(); // Get clearSelection from context
+  const { clearSelection, syncWithExistingTabs } = useTabSelectionContext(); // Get clearSelection and syncWithExistingTabs from context
   const [activeWindowId, setActiveWindowId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [sequenceActive, setSequenceActive] = useState<boolean>(false);
@@ -35,13 +35,17 @@ const Manager = () => {
       devLog(`${new Date()} - Received message from background:`, message); // Log received messages
       if (message.type === 'UPDATE_TABS' && message.tabs) {
         updateTabGroups(message.tabs); // Use the updated tabs
+
+        // Sync selected tabs with existing tabs
+        const existingTabIds = message.tabs.map(tab => tab.id).filter((id): id is number => id !== undefined);
+        syncWithExistingTabs(existingTabIds);
       } else if (message.type === 'BACKGROUND_INITIALIZED') {
         devLog(`${new Date()} - Background script initialized`);
       }
       // No need to handle REQUEST_INITIAL_DATA here, it's sent from client
     },
-    [updateTabGroups]
-  ); // Dependency array includes updateTabGroups
+    [updateTabGroups, syncWithExistingTabs]
+  );
 
   // Sync sequenceActive with its ref
   useEffect(() => {
@@ -167,7 +171,7 @@ const Manager = () => {
       }
     },
     [handleWindowGroupFocus]
-  ); // Include handleWindowGroupFocus as dependency
+  );
 
   // Effect for getting current window ID and setting up keydown listener
   useEffect(() => {
@@ -197,7 +201,7 @@ const Manager = () => {
       }
     },
     [clearSelection]
-  ); // Dependency array includes clearSelection
+  );
 
   const filteredTabGroups = tabGroups
     .map((group, index) => ({ ...group, windowGroupNumber: index }))

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,13 +19,15 @@ const Header = ({ searchQuery, onSearchQueryChange, searchBarRef }: HeaderProps)
   const totalTabCount = useTotalTabCount();
 
   const handleCloseSelectedTabs = async () => {
+    const tabsToClose = [...selectedTabIds]; // Copy the array before removal
     try {
-      const tabsToClose = [...selectedTabIds]; // Copy the array before removal
       await chrome.tabs.remove(tabsToClose);
-      // Remove only the closed tabs from selection
+      // Success: remove all from selection
       removeTabsFromSelection(tabsToClose);
       showToast(<Alert message={`Selected ${tabsToClose.length} tabs closed successfully.`} variant="success" />);
     } catch (error) {
+      // On error, don't update selection - let syncWithExistingTabs handle cleanup
+      // This prevents state inconsistency when tab removal fails
       showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);
       console.error('Error closing tabs:', error);
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,15 +14,17 @@ interface HeaderProps {
 }
 
 const Header = ({ searchQuery, onSearchQueryChange, searchBarRef }: HeaderProps) => {
-  const { selectedTabIds, clearSelection } = useTabSelectionContext();
+  const { selectedTabIds, removeTabsFromSelection } = useTabSelectionContext();
   const { showToast } = useToast();
   const totalTabCount = useTotalTabCount();
 
   const handleCloseSelectedTabs = async () => {
     try {
-      await chrome.tabs.remove(selectedTabIds);
-      clearSelection();
-      showToast(<Alert message={`Selected ${selectedTabIds.length} tabs closed successfully.`} variant="success" />);
+      const tabsToClose = [...selectedTabIds]; // Copy the array before removal
+      await chrome.tabs.remove(tabsToClose);
+      // Remove only the closed tabs from selection
+      removeTabsFromSelection(tabsToClose);
+      showToast(<Alert message={`Selected ${tabsToClose.length} tabs closed successfully.`} variant="success" />);
     } catch (error) {
       showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);
       console.error('Error closing tabs:', error);

--- a/src/components/WindowActions.tsx
+++ b/src/components/WindowActions.tsx
@@ -1,11 +1,7 @@
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
 import { useToast } from '../../src/components/ToastProvider';
 import Alert from '../../src/components/Alert';
-import {
-  countSelectedIds,
-  shouldBulkSelectBeChecked,
-  shouldCloseTabsBeDisabled,
-} from '../utils/windowActions';
+import { countSelectedIds, shouldBulkSelectBeChecked, shouldCloseTabsBeDisabled } from '../utils/windowActions';
 
 interface WindowActionsProps {
   windowId: number;
@@ -39,14 +35,16 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
       // Get all tabs in this window to remove them from selection
       const tabs = await chrome.tabs.query({ windowId });
       const tabIds = tabs.map(tab => tab.id).filter((id): id is number => id !== undefined);
-      
-      // Remove these tabs from selection before closing the window
-      removeTabsFromSelection(tabIds);
-      
-      // Close the window
+
+      // Close the window first
       await chrome.windows.remove(windowId);
+
+      // Remove these tabs from selection after successful close
+      removeTabsFromSelection(tabIds);
     } catch (error) {
       console.error('Error closing window:', error);
+      // Add user notification
+      showToast(<Alert message="Failed to close window" variant="error" />);
     }
   };
 

--- a/src/contexts/TabSelectionContext.tsx
+++ b/src/contexts/TabSelectionContext.tsx
@@ -1,4 +1,12 @@
 import { createContext, useContext, useState } from 'react';
+import {
+  syncSelectedTabsWithExisting,
+  addTabToSelection as addTabToSelectionUtil,
+  removeTabFromSelection as removeTabFromSelectionUtil,
+  addTabsToSelectionUnique,
+  removeTabsFromSelection as removeTabsFromSelectionUtil,
+  clearSelection as clearSelectionUtil,
+} from '../utils/tabSelection';
 
 interface TabSelectionContextProps {
   selectedTabIds: number[];
@@ -7,6 +15,7 @@ interface TabSelectionContextProps {
   clearSelection: () => void;
   addTabsToSelection: (tabIds: number[]) => void;
   removeTabsFromSelection: (tabIds: number[]) => void;
+  syncWithExistingTabs: (existingTabIds: number[]) => void;
 }
 
 const TabSelectionContext = createContext<TabSelectionContextProps | undefined>(undefined);
@@ -23,23 +32,27 @@ export const TabSelectionContextProvider = ({ children }: { children: React.Reac
   const [selectedTabIds, setSelectedTabIds] = useState<number[]>([]);
 
   const addTabToSelection = (tabId: number) => {
-    setSelectedTabIds([...selectedTabIds, tabId]);
+    setSelectedTabIds(prevIds => addTabToSelectionUtil(prevIds, tabId));
   };
 
   const removeTabFromSelection = (tabId: number) => {
-    setSelectedTabIds(selectedTabIds.filter(id => id !== tabId));
+    setSelectedTabIds(prevIds => removeTabFromSelectionUtil(prevIds, tabId));
   };
 
   const clearSelection = () => {
-    setSelectedTabIds([]);
+    setSelectedTabIds(clearSelectionUtil());
   };
 
   const addTabsToSelection = (tabIds: number[]) => {
-    setSelectedTabIds(prevSelectedTabIds => [...new Set([...prevSelectedTabIds, ...tabIds])]);
+    setSelectedTabIds(prevIds => addTabsToSelectionUnique(prevIds, tabIds));
   };
 
   const removeTabsFromSelection = (tabIds: number[]) => {
-    setSelectedTabIds(prevSelectedTabIds => prevSelectedTabIds.filter(id => !tabIds.includes(id)));
+    setSelectedTabIds(prevIds => removeTabsFromSelectionUtil(prevIds, tabIds));
+  };
+
+  const syncWithExistingTabs = (existingTabIds: number[]) => {
+    setSelectedTabIds(prevIds => syncSelectedTabsWithExisting(prevIds, existingTabIds));
   };
 
   const value: TabSelectionContextProps = {
@@ -49,6 +62,7 @@ export const TabSelectionContextProvider = ({ children }: { children: React.Reac
     clearSelection,
     addTabsToSelection,
     removeTabsFromSelection,
+    syncWithExistingTabs,
   };
 
   return <TabSelectionContext.Provider value={value}>{children}</TabSelectionContext.Provider>;

--- a/src/utils/tabSelection.test.ts
+++ b/src/utils/tabSelection.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import {
+  syncSelectedTabsWithExisting,
+  addTabToSelection,
+  removeTabFromSelection,
+  addTabsToSelectionUnique,
+  removeTabsFromSelection,
+  clearSelection,
+} from './tabSelection';
+
+describe('tabSelection utilities', () => {
+  describe('syncSelectedTabsWithExisting', () => {
+    it('keeps only existing tab IDs from selection', () => {
+      const selected = [1, 2, 3, 4, 5];
+      const existing = [2, 4, 6, 8];
+
+      const result = syncSelectedTabsWithExisting(selected, existing);
+
+      expect(result).toEqual([2, 4]);
+    });
+
+    it('removes non-existent tab IDs', () => {
+      const selected = [1, 2, 3];
+      const existing = [4, 5, 6];
+
+      const result = syncSelectedTabsWithExisting(selected, existing);
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles empty selected tabs', () => {
+      const result = syncSelectedTabsWithExisting([], [1, 2, 3]);
+      expect(result).toEqual([]);
+    });
+
+    it('handles empty existing tabs (all selected tabs removed)', () => {
+      const result = syncSelectedTabsWithExisting([1, 2, 3], []);
+      expect(result).toEqual([]);
+    });
+
+    it('handles both arrays empty', () => {
+      const result = syncSelectedTabsWithExisting([], []);
+      expect(result).toEqual([]);
+    });
+
+    it('preserves selection order', () => {
+      const selected = [5, 3, 1, 4, 2];
+      const existing = [1, 2, 3, 4, 5, 6];
+
+      const result = syncSelectedTabsWithExisting(selected, existing);
+
+      expect(result).toEqual([5, 3, 1, 4, 2]);
+    });
+
+    it('handles duplicate IDs in existing tabs', () => {
+      const selected = [1, 2, 3];
+      const existing = [1, 1, 2, 2, 3, 3];
+
+      const result = syncSelectedTabsWithExisting(selected, existing);
+
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('works with large datasets efficiently', () => {
+      const selected = Array.from({ length: 10000 }, (_, i) => i);
+      const existing = Array.from({ length: 10000 }, (_, i) => i * 2);
+
+      const result = syncSelectedTabsWithExisting(selected, existing);
+
+      expect(result.length).toBeLessThanOrEqual(5000);
+      result.forEach(id => {
+        expect(existing).toContain(id);
+      });
+    });
+  });
+
+  describe('addTabToSelection', () => {
+    it('adds a new tab ID to selection', () => {
+      const result = addTabToSelection([1, 2], 3);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('does not add duplicate tab ID', () => {
+      const result = addTabToSelection([1, 2, 3], 2);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles empty selection', () => {
+      const result = addTabToSelection([], 1);
+      expect(result).toEqual([1]);
+    });
+  });
+
+  describe('removeTabFromSelection', () => {
+    it('removes specified tab ID from selection', () => {
+      const result = removeTabFromSelection([1, 2, 3], 2);
+      expect(result).toEqual([1, 3]);
+    });
+
+    it('handles non-existent tab ID', () => {
+      const result = removeTabFromSelection([1, 2, 3], 4);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles empty selection', () => {
+      const result = removeTabFromSelection([], 1);
+      expect(result).toEqual([]);
+    });
+
+    it('removes all occurrences if duplicates exist', () => {
+      const result = removeTabFromSelection([1, 2, 2, 3], 2);
+      expect(result).toEqual([1, 3]);
+    });
+  });
+
+  describe('addTabsToSelectionUnique', () => {
+    it('adds multiple tabs without duplicates', () => {
+      const result = addTabsToSelectionUnique([1, 2], [3, 4]);
+      expect(result).toEqual([1, 2, 3, 4]);
+    });
+
+    it('prevents duplicate additions', () => {
+      const result = addTabsToSelectionUnique([1, 2], [2, 3]);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles empty initial selection', () => {
+      const result = addTabsToSelectionUnique([], [1, 2, 3]);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles empty tabs to add', () => {
+      const result = addTabsToSelectionUnique([1, 2], []);
+      expect(result).toEqual([1, 2]);
+    });
+
+    it('removes duplicates from existing selection', () => {
+      const result = addTabsToSelectionUnique([1, 1, 2, 2], [3]);
+      expect(result).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('removeTabsFromSelection', () => {
+    it('removes multiple tabs from selection', () => {
+      const result = removeTabsFromSelection([1, 2, 3, 4, 5], [2, 4]);
+      expect(result).toEqual([1, 3, 5]);
+    });
+
+    it('handles non-existent tab IDs', () => {
+      const result = removeTabsFromSelection([1, 2, 3], [4, 5]);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('handles empty selection', () => {
+      const result = removeTabsFromSelection([], [1, 2]);
+      expect(result).toEqual([]);
+    });
+
+    it('handles empty tabs to remove', () => {
+      const result = removeTabsFromSelection([1, 2, 3], []);
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('removes all matching tabs', () => {
+      const result = removeTabsFromSelection([1, 2, 3], [1, 2, 3]);
+      expect(result).toEqual([]);
+    });
+
+    it('works efficiently with large datasets', () => {
+      const selected = Array.from({ length: 10000 }, (_, i) => i);
+      const toRemove = Array.from({ length: 5000 }, (_, i) => i * 2); // [0, 2, 4, 6, ..., 9998]
+
+      const result = removeTabsFromSelection(selected, toRemove);
+
+      // toRemove contains 5000 even numbers from 0 to 9998
+      // All of these are in the selected array (0-9999)
+      // So we remove 5000 items from 10000, leaving 5000
+      expect(result.length).toBe(5000);
+      toRemove.forEach(id => {
+        if (id < 10000) {
+          expect(result).not.toContain(id);
+        }
+      });
+    });
+  });
+
+  describe('clearSelection', () => {
+    it('returns empty array', () => {
+      const result = clearSelection();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('handles Close Window scenario correctly', () => {
+      // User has tabs 1-5 selected across 2 windows
+      const selectedTabIds = [1, 2, 3, 4, 5];
+      // Window 1 has tabs 1-3, Window 2 has tabs 4-5
+      // User closes Window 1
+      const remainingTabs = [4, 5, 6, 7]; // 6, 7 are other unselected tabs
+
+      const result = syncSelectedTabsWithExisting(selectedTabIds, remainingTabs);
+
+      expect(result).toEqual([4, 5]);
+    });
+
+    it('handles Close Tabs scenario correctly', () => {
+      // User has selected specific tabs
+      const selectedTabIds = [2, 4, 6];
+      // User clicks Close Tabs
+      const tabsToRemove = [2, 4, 6];
+
+      const result = removeTabsFromSelection(selectedTabIds, tabsToRemove);
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles browser tab close scenario correctly', () => {
+      // User has multiple tabs selected
+      const selectedTabIds = [1, 2, 3, 4, 5];
+      // User closes tab 3 using browser's X button
+      const remainingTabs = [1, 2, 4, 5, 6, 7];
+
+      const result = syncSelectedTabsWithExisting(selectedTabIds, remainingTabs);
+
+      expect(result).toEqual([1, 2, 4, 5]);
+    });
+  });
+});

--- a/src/utils/tabSelection.ts
+++ b/src/utils/tabSelection.ts
@@ -1,0 +1,62 @@
+/**
+ * Sync selected tab IDs with existing tabs, removing any non-existent tabs from selection
+ * @param selectedTabIds Currently selected tab IDs
+ * @param existingTabIds IDs of tabs that actually exist
+ * @returns Filtered array containing only selected tabs that exist
+ */
+export function syncSelectedTabsWithExisting(selectedTabIds: number[], existingTabIds: number[]): number[] {
+  const existingTabIdSet = new Set(existingTabIds);
+  return selectedTabIds.filter(tabId => existingTabIdSet.has(tabId));
+}
+
+/**
+ * Add a single tab to selection if not already selected
+ * @param selectedTabIds Currently selected tab IDs
+ * @param tabId Tab ID to add
+ * @returns Updated selection array
+ */
+export function addTabToSelection(selectedTabIds: number[], tabId: number): number[] {
+  if (selectedTabIds.includes(tabId)) {
+    return selectedTabIds;
+  }
+  return [...selectedTabIds, tabId];
+}
+
+/**
+ * Remove a single tab from selection
+ * @param selectedTabIds Currently selected tab IDs
+ * @param tabId Tab ID to remove
+ * @returns Updated selection array
+ */
+export function removeTabFromSelection(selectedTabIds: number[], tabId: number): number[] {
+  return selectedTabIds.filter(id => id !== tabId);
+}
+
+/**
+ * Add multiple tabs to selection, avoiding duplicates
+ * @param selectedTabIds Currently selected tab IDs
+ * @param tabIds Tab IDs to add
+ * @returns Updated selection array with unique IDs
+ */
+export function addTabsToSelectionUnique(selectedTabIds: number[], tabIds: number[]): number[] {
+  return [...new Set([...selectedTabIds, ...tabIds])];
+}
+
+/**
+ * Remove multiple tabs from selection
+ * @param selectedTabIds Currently selected tab IDs
+ * @param tabIds Tab IDs to remove
+ * @returns Updated selection array
+ */
+export function removeTabsFromSelection(selectedTabIds: number[], tabIds: number[]): number[] {
+  const tabIdsToRemove = new Set(tabIds);
+  return selectedTabIds.filter(id => !tabIdsToRemove.has(id));
+}
+
+/**
+ * Clear all selections
+ * @returns Empty array
+ */
+export function clearSelection(): number[] {
+  return [];
+}


### PR DESCRIPTION
Previously, the selection count badge would not update when tabs were deleted through various methods (Close Tabs, Close Window, browser tab close).
This caused the badge to show incorrect counts.

Changes:
- Extract tab selection logic into pure functions (src/utils/tabSelection.ts)
- Add syncWithExistingTabs method to TabSelectionContext
- Sync selection state on UPDATE_TABS messages from background script
- Update Close Tabs/Window actions to only remove deleted tabs from selection
- Add comprehensive unit tests for selection utilities

This ensures the selection count is always accurate regardless of how tabs are closed (extension buttons, browser UI, other extensions, etc).

