### PR TITLE
Create .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # npm パッケージの依存関係更新
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    # メジャーバージョンの更新を無視
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    # プルリクエストの設定
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dependabot"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"


### PR DESCRIPTION
This pull request introduces a new Dependabot configuration to automate npm dependency updates. The configuration schedules weekly update checks, limits major version updates, and customizes pull request settings.

Dependency management automation:

* Added `.github/dependabot.yml` to enable Dependabot for npm dependencies, scheduling weekly updates every Friday at 09:00 Asia/Tokyo time, ignoring major version updates, and setting pull request labels and commit message prefixes.