### PR TITLE
Add inert state management for deletion operations

### DIFF
--- a/entrypoints/manager/main.tsx
+++ b/entrypoints/manager/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { TabSelectionContextProvider } from '../../src/contexts/TabSelectionContext';
 import { TabGroupProvider } from '@/src/contexts/TabGroupContext';
+import { DeletionStateProvider } from '../../src/contexts/DeletionStateContext';
 import { ToastProvider } from '../../src/components/ToastProvider';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -10,7 +11,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ToastProvider>
       <TabGroupProvider>
         <TabSelectionContextProvider>
-          <App />
+          <DeletionStateProvider>
+            <App />
+          </DeletionStateProvider>
         </TabSelectionContextProvider>
       </TabGroupProvider>
     </ToastProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import SearchBar from './SearchBar';
 import ThemeSwitcher from './ThemeSwitcher';
 import TabCountBadge from './TabCountBadge';
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
+import { useDeletionState } from '../contexts/DeletionStateContext';
 import { useToast } from '../../src/components/ToastProvider';
 import Alert from '../../src/components/Alert';
 import { useTotalTabCount } from '../hooks/useTotalTabCount';
@@ -15,11 +16,14 @@ interface HeaderProps {
 
 const Header = ({ searchQuery, onSearchQueryChange, searchBarRef }: HeaderProps) => {
   const { selectedTabIds, removeTabsFromSelection } = useTabSelectionContext();
+  const { setDeletingState } = useDeletionState();
   const { showToast } = useToast();
   const totalTabCount = useTotalTabCount();
 
   const handleCloseSelectedTabs = async () => {
     const tabsToClose = [...selectedTabIds]; // Copy the array before removal
+    // Mark all tabs as deleting
+    tabsToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
     try {
       await chrome.tabs.remove(tabsToClose);
       // Success: remove all from selection

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,8 @@ const Header = ({ searchQuery, onSearchQueryChange, searchBarRef }: HeaderProps)
       removeTabsFromSelection(tabsToClose);
       showToast(<Alert message={`Selected ${tabsToClose.length} tabs closed successfully.`} variant="success" />);
     } catch (error) {
+      // Reset deleting state for all tabs that failed to close
+      tabsToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
       // On error, don't update selection - let syncWithExistingTabs handle cleanup
       // This prevents state inconsistency when tab removal fails
       showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -74,6 +74,7 @@ const TabItem = ({ tab }: TabItemProps) => {
     try {
       await chrome.tabs.remove(tab.id!);
     } catch (error) {
+      setDeletingState({ type: 'tab', id: tab.id!, isDeleting: false });
       showToast(<Alert message="Failed to close tab" />);
       console.error('Failed to close tab:', error);
     }

--- a/src/components/WindowActions.tsx
+++ b/src/components/WindowActions.tsx
@@ -45,6 +45,7 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
       // Remove these tabs from selection after successful close
       removeTabsFromSelection(tabIds);
     } catch (error) {
+      setDeletingState({ type: 'window', id: windowId, isDeleting: false });
       console.error('Error closing window:', error);
       // Add user notification
       showToast(<Alert message="Failed to close window" variant="error" />);
@@ -76,6 +77,8 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
       removeTabsFromSelection(tabIdsInWindow);
       showToast(<Alert message={`Selected ${tabIdsInWindow.length} tabs closed successfully.`} variant="success" />);
     } catch (error) {
+      // Reset deleting state for all tabs that failed to close
+      tabIdsInWindow.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
       showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);
       console.error('Error closing tabs:', error);
     }

--- a/src/components/WindowGroup.tsx
+++ b/src/components/WindowGroup.tsx
@@ -2,6 +2,7 @@ import WindowHeader from './WindowHeader';
 import TabList from './TabList';
 import WindowActions from './WindowActions';
 import { useWindowGroupContext } from '../contexts/WindowGroupContext';
+import { useDeletionState } from '../contexts/DeletionStateContext';
 
 interface WindowGroupProps {
   tabGroup: {
@@ -12,20 +13,24 @@ interface WindowGroupProps {
 }
 const WindowGroup = ({ tabGroup, activeWindowId }: WindowGroupProps) => {
   const { windowGroupNumber } = useWindowGroupContext();
-  
+  const { isDeleting } = useDeletionState();
+  const isDeletingWindow = isDeleting({ type: 'window', id: tabGroup.windowId });
+
   return (
-    <div 
-      className="collapse collapse-arrow bg-base-100 border-base-300 border rounded-none mb-4"
-      data-window-group-number={windowGroupNumber}
-      data-window-id={tabGroup.windowId}
-    >
-      <input id={`window-group-collapse-${tabGroup.windowId}`} type="checkbox" defaultChecked={true} />
-      <div className="collapse-title font-semibold">
-        <WindowHeader windowId={tabGroup.windowId} activeWindowId={activeWindowId} />
-      </div>
-      <div className="collapse-content">
-        <WindowActions windowId={tabGroup.windowId} visibleTabs={tabGroup.tabs} />
-        <TabList tabs={tabGroup.tabs} />
+    <div inert={isDeletingWindow || undefined} className="inert:opacity-50">
+      <div
+        className="collapse collapse-arrow bg-base-100 border-base-300 border rounded-none mb-4"
+        data-window-group-number={windowGroupNumber}
+        data-window-id={tabGroup.windowId}
+      >
+        <input id={`window-group-collapse-${tabGroup.windowId}`} type="checkbox" defaultChecked={true} />
+        <div className="collapse-title font-semibold">
+          <WindowHeader windowId={tabGroup.windowId} activeWindowId={activeWindowId} />
+        </div>
+        <div className="collapse-content">
+          <WindowActions windowId={tabGroup.windowId} visibleTabs={tabGroup.tabs} />
+          <TabList tabs={tabGroup.tabs} />
+        </div>
       </div>
     </div>
   );

--- a/src/contexts/DeletionStateContext.tsx
+++ b/src/contexts/DeletionStateContext.tsx
@@ -54,22 +54,24 @@ export const DeletionStateProvider: React.FC<{ children: ReactNode }> = ({ child
 
   const cleanupNonExistentItems = useCallback(
     ({ existingTabIds, existingWindowIds }: { existingTabIds: number[]; existingWindowIds: number[] }) => {
+      const existingTabIdsSet = new Set(existingTabIds);
       // Clean up tab IDs that no longer exist
       setDeletingTabIds(prev => {
         const next = new Set<number>();
         prev.forEach(id => {
-          if (existingTabIds.includes(id)) {
+          if (existingTabIdsSet.has(id)) {
             next.add(id);
           }
         });
         return next.size === prev.size ? prev : next;
       });
 
+      const existingWindowIdsSet = new Set(existingWindowIds);
       // Clean up window IDs that no longer exist
       setDeletingWindowIds(prev => {
         const next = new Set<number>();
         prev.forEach(id => {
-          if (existingWindowIds.includes(id)) {
+          if (existingWindowIdsSet.has(id)) {
             next.add(id);
           }
         });

--- a/src/contexts/DeletionStateContext.tsx
+++ b/src/contexts/DeletionStateContext.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+interface DeletionStateContextType {
+  deletingWindowIds: Set<number>;
+  deletingTabIds: Set<number>;
+  setDeletingState: (params: { type: 'window' | 'tab'; id: number; isDeleting: boolean }) => void;
+  isDeleting: (params: { type: 'window' | 'tab'; id: number }) => boolean;
+  cleanupNonExistentItems: (params: { existingTabIds: number[]; existingWindowIds: number[] }) => void;
+}
+
+const DeletionStateContext = createContext<DeletionStateContextType | undefined>(undefined);
+
+export const DeletionStateProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [deletingWindowIds, setDeletingWindowIds] = useState<Set<number>>(new Set());
+  const [deletingTabIds, setDeletingTabIds] = useState<Set<number>>(new Set());
+
+  const setDeletingState = useCallback(
+    ({ type, id, isDeleting }: { type: 'window' | 'tab'; id: number; isDeleting: boolean }) => {
+      if (type === 'window') {
+        setDeletingWindowIds(prev => {
+          const next = new Set(prev);
+          if (isDeleting) {
+            next.add(id);
+          } else {
+            next.delete(id);
+          }
+          return next;
+        });
+      } else {
+        setDeletingTabIds(prev => {
+          const next = new Set(prev);
+          if (isDeleting) {
+            next.add(id);
+          } else {
+            next.delete(id);
+          }
+          return next;
+        });
+      }
+    },
+    []
+  );
+
+  const isDeleting = useCallback(
+    ({ type, id }: { type: 'window' | 'tab'; id: number }) => {
+      if (type === 'window') {
+        return deletingWindowIds.has(id);
+      } else {
+        return deletingTabIds.has(id);
+      }
+    },
+    [deletingWindowIds, deletingTabIds]
+  );
+
+  const cleanupNonExistentItems = useCallback(
+    ({ existingTabIds, existingWindowIds }: { existingTabIds: number[]; existingWindowIds: number[] }) => {
+      // Clean up tab IDs that no longer exist
+      setDeletingTabIds(prev => {
+        const next = new Set<number>();
+        prev.forEach(id => {
+          if (existingTabIds.includes(id)) {
+            next.add(id);
+          }
+        });
+        return next.size === prev.size ? prev : next;
+      });
+
+      // Clean up window IDs that no longer exist
+      setDeletingWindowIds(prev => {
+        const next = new Set<number>();
+        prev.forEach(id => {
+          if (existingWindowIds.includes(id)) {
+            next.add(id);
+          }
+        });
+        return next.size === prev.size ? prev : next;
+      });
+    },
+    []
+  );
+
+  return (
+    <DeletionStateContext.Provider
+      value={{
+        deletingWindowIds,
+        deletingTabIds,
+        setDeletingState,
+        isDeleting,
+        cleanupNonExistentItems,
+      }}
+    >
+      {children}
+    </DeletionStateContext.Provider>
+  );
+};
+
+export const useDeletionState = () => {
+  const context = useContext(DeletionStateContext);
+  if (!context) {
+    throw new Error('useDeletionState must be used within a DeletionStateProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
Implement UI blocking during tab/window deletion to prevent user interaction
while operations are in progress. The inert attribute provides visual feedback
and disables all interactions until DOM updates complete.

- Create DeletionStateContext with object-based API for state management
- Add inert wrapper divs to WindowGroup and TabItem components
- Convert TabItem deletion handler to async/await pattern
- Update all deletion handlers to manage inert state (no finally blocks)
- Implement automatic cleanup for deleted items on UPDATE_TABS messages
- Add visual feedback with opacity-50 during deletion

The implementation intentionally omits finally blocks to maintain inert state until DOM elements are actually removed,
preventing premature re-enabling of user interactions.

