### PR TITLE
feat: add keyboard shortcuts modal with ? key trigger

### DIFF
--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -8,6 +8,7 @@ import { useTabGroupContext } from '../../src/contexts/TabGroupContext';
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext'; // Import TabSelectionContext
 import { useDeletionState } from '../../src/contexts/DeletionStateContext'; // Import DeletionStateContext
 import { useBackgroundConnection } from '../../src/hooks/useBackgroundConnection'; // Import the hook
+import KeyboardShortcutsModal from '../../src/components/KeyboardShortcutsModal';
 import './style.css';
 
 // Constants for keyboard navigation
@@ -140,6 +141,16 @@ const Manager = () => {
         return;
       }
 
+      // Handle '?' (Shift + /) for keyboard shortcuts modal
+      if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+        event.preventDefault();
+        const modal = document.getElementById('keyboard-shortcuts-modal') as HTMLDialogElement;
+        if (modal) {
+          modal.showModal();
+        }
+        return;
+      }
+
       // Handle ESC key to cancel sequence
       if (event.key === 'Escape' && sequenceActiveRef.current) {
         event.preventDefault();
@@ -234,6 +245,7 @@ const Manager = () => {
           Press 0-9 to jump to Window Group
         </div>
       )}
+      <KeyboardShortcutsModal />
     </TabFocusProvider>
   );
 };

--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -142,7 +142,7 @@ const Manager = () => {
       }
 
       // Handle '?' (Shift + /) for keyboard shortcuts modal
-      if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+      if (event.key === '?') {
         event.preventDefault();
         const modal = document.getElementById('keyboard-shortcuts-modal') as HTMLDialogElement;
         if (modal) {

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,55 @@
+const KeyboardShortcutsModal = () => {
+  const shortcuts = {
+    'Global Shortcuts': [
+      { key: '/', description: 'Focus search bar' },
+      { key: '?', description: 'Show keyboard shortcuts (this modal)' },
+      { key: 'w + 0', description: 'Jump to current window' },
+      { key: 'w + 1-9', description: 'Jump to Window Group by number' },
+      { key: 'ESC', description: 'Cancel window jump sequence' },
+    ],
+    'Tab Navigation': [
+      { key: 'j', description: 'Move to next tab (down)' },
+      { key: 'k', description: 'Move to previous tab (up)' },
+      { key: 'gg', description: 'Jump to first tab (press g twice)' },
+      { key: 'Shift + g', description: 'Jump to last tab' },
+      { key: 'G', description: 'Jump to last tab' },
+    ],
+    'Tab Actions': [{ key: 'Space', description: 'Toggle tab selection' }],
+  };
+
+  return (
+    <dialog id="keyboard-shortcuts-modal" className="modal">
+      <div className="modal-box max-w-2xl">
+        <h3 className="font-bold text-lg mb-4">Keyboard Shortcuts</h3>
+
+        <div className="space-y-6">
+          {Object.entries(shortcuts).map(([category, items]) => (
+            <div key={category}>
+              <h4 className="font-semibold text-sm opacity-70 mb-2">{category}</h4>
+              <div className="space-y-1">
+                {items.map(({ key, description }) => (
+                  <div key={key} className="flex items-center gap-4 py-1">
+                    <kbd className="kbd kbd-sm min-w-[80px] text-center">{key}</kbd>
+                    <span className="text-sm">{description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="modal-action">
+          <form method="dialog">
+            <button className="btn btn-sm">Close</button>
+          </form>
+        </div>
+      </div>
+
+      <form method="dialog" className="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  );
+};
+
+export default KeyboardShortcutsModal;

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -12,7 +12,6 @@ const KeyboardShortcutsModal = () => {
       { key: 'k', description: 'Move to previous tab (up)' },
       { key: 'gg', description: 'Jump to first tab (press g twice)' },
       { key: 'Shift + g', description: 'Jump to last tab' },
-      { key: 'G', description: 'Jump to last tab' },
     ],
     'Tab Actions': [{ key: 'Space', description: 'Toggle tab selection' }],
   };


### PR DESCRIPTION
Implement a help modal that displays all available keyboard shortcuts when pressing the ? key (Shift + /).
The modal uses daisyUI's HTML dialog element for better accessibility and native ESC key support.

- Create KeyboardShortcutsModal component with categorized shortcuts display
- Add ? key handler to Manager component to trigger modal
- Organize shortcuts into Global, Tab Navigation, and Tab Actions categories
- Use kbd elements for visual keyboard key representation

