### PR TITLE
Fix infinite loop in tab update events

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -31,10 +31,13 @@ export default defineBackground(() => {
   });
 
   // Listen for tab updates
-  browser.tabs.onUpdated.addListener(async () => {
-    devLog(`${new Date()} - onUpdated:`, port);
-    if (port) {
-      updateTabs(port);
+  browser.tabs.onUpdated.addListener(async (tabId, changeInfo, _tab) => {
+    // Only process when the tab status is 'complete' to avoid multiple updates during loading
+    if (changeInfo.status === 'complete') {
+      devLog(`${new Date()} - onUpdated (complete) for tab ${tabId}`);
+      if (port) {
+        updateTabs(port);
+      }
     }
   });
 


### PR DESCRIPTION
- Add proper parameters to onUpdated event listener
- Only process tab updates when status is 'complete'
- Prevents multiple updates during page loading (loading -> complete)
- Resolves excessive console logging in dev mode

The issue was caused by onUpdated firing multiple times per tab during page load without filtering by status.
This fix ensures updates are only sent when tabs finish loading.
