### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lazycluster",
   "description": "A Chrome extension for enhanced tab and window management",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
This pull request includes a minor version bump for the `lazycluster` Chrome extension, updating the version from 1.1.0 to 1.1.1 in `package.json`.