### PR TITLE
Add Shift+M keyboard shortcut to jump to middle tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Chrome extension for enhanced tab and window management, inspired by the origi
   - `?`: Show keyboard shortcuts help modal
   - `j/k`: Navigate up/down through tabs
   - `gg/G`: Jump to first/last tab (double press `g` for first, `Shift+g` for last)
+  - `Shift+m`: Jump to middle tab
   - `Space`: Toggle tab selection
   - `w + [0-9]`: Quick jump to Window Groups
     - `w` then `1-9`: Jump to specific Window Group

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -10,6 +10,7 @@ const KeyboardShortcutsModal = () => {
     'Tab Navigation': [
       { key: 'j', description: 'Move to next tab (down)' },
       { key: 'k', description: 'Move to previous tab (up)' },
+      { key: 'Shift + m', description: 'Jump to middle tab' },
       { key: 'gg', description: 'Jump to first tab (press g twice)' },
       { key: 'Shift + g', description: 'Jump to last tab' },
     ],

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -33,6 +33,11 @@ const TabList = ({ tabs }: TabListProps) => {
       case 'j':
         nextIndex = (activeIndex + 1) % tabItems.length;
         break;
+      case 'M':
+        if (tabItems.length >= 3) {
+          nextIndex = Math.floor(tabItems.length / 2);
+        }
+        break;
       case 'g': {
         const now = Date.now();
         if (lastKey === 'g' && now - lastKeyTime < 500) {


### PR DESCRIPTION
This pull request introduces a new keyboard shortcut to jump directly to the middle tab in the tab list, enhancing navigation efficiency for users. 

Feature implementation:

* Implemented the logic for handling the `Shift+m` (i.e., `'M'`) shortcut to jump to the middle tab in the `TabList` component (`TabList.tsx`).