### PR TITLE
refactor: Replace gg/G with Shift+H/L for vim-style navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A Chrome extension for enhanced tab and window management, inspired by the origi
 - **Intuitive Keyboard Navigation:** Navigate and select tabs efficiently using familiar keyboard shortcuts for a smooth workflow:
   - `?`: Show keyboard shortcuts help modal
   - `j/k`: Navigate up/down through tabs
-  - `gg/G`: Jump to first/last tab (double press `g` for first, `Shift+g` for last)
-  - `Shift+m`: Jump to middle tab
+  - `Shift+h/l`: Jump to first/last tab in current window group (vim-style: High/Low)
+  - `Shift+m`: Jump to middle tab in current window group (vim-style: Middle)
   - `Space`: Toggle tab selection
   - `w + [0-9]`: Quick jump to Window Groups
     - `w` then `1-9`: Jump to specific Window Group

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -10,9 +10,9 @@ const KeyboardShortcutsModal = () => {
     'Tab Navigation': [
       { key: 'j', description: 'Move to next tab (down)' },
       { key: 'k', description: 'Move to previous tab (up)' },
-      { key: 'Shift + m', description: 'Jump to middle tab' },
-      { key: 'gg', description: 'Jump to first tab (press g twice)' },
-      { key: 'Shift + g', description: 'Jump to last tab' },
+      { key: 'Shift + h', description: 'Jump to first tab in window group' },
+      { key: 'Shift + m', description: 'Jump to middle tab in window group' },
+      { key: 'Shift + l', description: 'Jump to last tab in window group' },
     ],
     'Tab Actions': [{ key: 'Space', description: 'Toggle tab selection' }],
   };

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -8,9 +8,6 @@ interface TabListProps {
 const TabList = ({ tabs }: TabListProps) => {
   const listRef = useRef<HTMLUListElement>(null);
 
-  let lastKeyTime = 0;
-  let lastKey = '';
-
   const handleKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
     const activeElement = document.activeElement;
     if (!activeElement || !listRef.current?.contains(activeElement)) {
@@ -33,24 +30,20 @@ const TabList = ({ tabs }: TabListProps) => {
       case 'j':
         nextIndex = (activeIndex + 1) % tabItems.length;
         break;
+      case 'H':
+        if (event.shiftKey) {
+          nextIndex = 0;
+        }
+        break;
       case 'M':
-        if (tabItems.length >= 3) {
+        if (event.shiftKey && tabItems.length >= 3) {
           nextIndex = Math.floor(tabItems.length / 2);
         }
         break;
-      case 'g': {
-        const now = Date.now();
-        if (lastKey === 'g' && now - lastKeyTime < 500) {
-          nextIndex = 0;
-        } else if (event.shiftKey) {
+      case 'L':
+        if (event.shiftKey) {
           nextIndex = tabItems.length - 1;
         }
-        lastKey = 'g';
-        lastKeyTime = now;
-        break;
-      }
-      case 'G':
-        nextIndex = tabItems.length - 1;
         break;
     }
 


### PR DESCRIPTION
- Change `gg`/`G` to `Shift+H`/`L` to match vim's screen navigation (H=High, L=Low)
- Update `Shift+M` to explicitly require Shift modifier for consistency
- Remove unused double-press detection logic for `gg`
- Update keyboard shortcuts documentation in README and CLAUDE.md

This aligns with vim's philosophy where H/M/L represent positions within the current "screen" (window group in our case).

Update contents in KeyboardShortcutModal
