### PR TITLE
fix: Align WindowActions checkbox with tab items

### DIFF
--- a/src/components/WindowActions.tsx
+++ b/src/components/WindowActions.tsx
@@ -91,7 +91,7 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
   return (
     <>
       <ul className="list shadow-md">
-        <li className="list-row p-2 items-center rounded-none gap-1.5">
+        <li className="list-row p-2 items-center rounded-none gap-1.5 border-l-[3px] border-l-transparent">
           <div>
             <input
               id={`bulk-select-tabs-on-window-${windowId}`}


### PR DESCRIPTION
Add transparent 3px left border to WindowActions list item to match the border spacing introduced for tab group colors in tab items.
This ensures vertical alignment between window-level bulk select checkbox and individual tab checkboxes.
