### PR TITLE
fix: Optimize TabItem useEffect dependency to tab.groupId only

### DIFF
--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -60,7 +60,7 @@ const TabItem = ({ tab }: TabItemProps) => {
       }
     };
     fetchGroupColor();
-  }, [tab]);
+  }, [tab.groupId]);
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();


### PR DESCRIPTION
This pull request makes a minor update to the `TabItem` component to optimize the effect dependency. The effect that fetches the group color now only runs when the `tab.groupId` changes, rather than any change to the entire `tab` object.

- Optimized the dependency array in the effect hook of `TabItem` to depend specifically on `tab.groupId` instead of the whole `tab` object, reducing unnecessary re-renders and fetches.