### PR TITLE
Bump version to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lazycluster",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lazycluster",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@tailwindcss/vite": "^4.1.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lazycluster",
   "description": "A Chrome extension for enhanced tab and window management",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
This pull request updates the version number of the `lazycluster` Chrome extension from 1.1.1 to 1.2.0 in the `package.json` file.