### PR TITLE
fix: prevent option text wrapping in inactive tabs threshold select

### DIFF
--- a/src/components/InactivesView.tsx
+++ b/src/components/InactivesView.tsx
@@ -69,7 +69,7 @@ const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThreshold
         </div>
         <div className="flex items-center gap-3">
           <select
-            className="select select-sm"
+            className="select select-sm [&>option]:[padding-inline:0]"
             value={thresholdMs}
             onChange={e => onThresholdChange(Number(e.target.value))}
           >


### PR DESCRIPTION
## Summary

- Inactive Tabs の閾値セレクトで、対象タブが存在しない場合にドロップダウンの選択肢テキストが折り返して表示される問題を修正
- daisyUI の `.select-sm option` に適用される `padding-inline: .625rem` が原因で、ネイティブドロップダウンのテキスト描画領域が圧迫されていた
- `[&>option]:[padding-inline:0]` Tailwind arbitrary variant で上書きして修正

## Root cause

The browser's native `<select>` dropdown renders at the element's computed width, but daisyUI applies `padding-inline: .625rem` to `option` elements via `.select-sm option`. The select's intrinsic width calculation does not account for this CSS padding on options, so the dropdown popup renders options with insufficient text area, causing wrapping.

## Test plan

- [x] Inactive Tabs ビューを開き、対象タブが 0 件の状態でドロップダウンを開く
- [x] "1 day", "3 days", "7 days" が1行で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)