### PR TITLE
feat: Save Tabs feature (OneTab-like)

### DIFF
--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -5,6 +5,8 @@ import type { ViewMode } from '../../src/components/Header';
 import WindowGroupList from '../../src/components/WindowGroupList';
 import DuplicatesView from '../../src/components/DuplicatesView';
 import InactivesView from '../../src/components/InactivesView';
+import SavedTabsView from '../../src/components/SavedTabsView';
+import { useSavedTabs } from '../../src/hooks/useSavedTabs';
 import { TabFocusProvider } from '../../src/contexts/TabFocusContext';
 import { useTabGroupContext } from '../../src/contexts/TabGroupContext';
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
@@ -26,7 +28,7 @@ interface BackgroundMessage {
 
 const getViewFromHash = (): ViewMode => {
   const hash = window.location.hash.slice(1);
-  if (hash === 'duplicates' || hash === 'inactives') return hash;
+  if (hash === 'duplicates' || hash === 'inactives' || hash === 'saved') return hash;
   return 'tabs';
 };
 
@@ -40,6 +42,7 @@ const Manager = () => {
   const [allTabs, setAllTabs] = useState<chrome.tabs.Tab[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>(getViewFromHash);
   const [inactiveThresholdMs, setInactiveThresholdMs] = useState(DEFAULT_INACTIVE_THRESHOLD_MS);
+  const { savedTabGroups, saveInactiveTabs, restoreGroup, deleteGroup, clearAll } = useSavedTabs();
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   // Sync viewMode with URL hash
@@ -139,6 +142,7 @@ const Manager = () => {
         viewMode={viewMode}
         onViewChange={changeView}
         inactiveThresholdMs={inactiveThresholdMs}
+        savedTabGroupCount={savedTabGroups.length}
       />
       <div className="p-5 pt-0">
         {viewMode === 'tabs' && (
@@ -151,7 +155,16 @@ const Manager = () => {
           <DuplicatesView allTabs={allTabs} windowLabels={windowLabels} onBack={() => changeView('tabs')} />
         )}
         {viewMode === 'inactives' && (
-          <InactivesView allTabs={allTabs} windowLabels={windowLabels} onBack={() => changeView('tabs')} thresholdMs={inactiveThresholdMs} onThresholdChange={setInactiveThresholdMs} />
+          <InactivesView allTabs={allTabs} windowLabels={windowLabels} onBack={() => changeView('tabs')} thresholdMs={inactiveThresholdMs} onThresholdChange={setInactiveThresholdMs} onSaveAll={saveInactiveTabs} />
+        )}
+        {viewMode === 'saved' && (
+          <SavedTabsView
+            savedTabGroups={savedTabGroups}
+            onBack={() => changeView('tabs')}
+            onRestoreGroup={restoreGroup}
+            onDeleteGroup={deleteGroup}
+            onClearAll={clearAll}
+          />
         )}
       </div>
       {sequenceActive && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ import { useTotalTabCount } from '../hooks/useTotalTabCount';
 import { findDuplicateTabs, countDuplicateTabs } from '../utils/duplicateDetection';
 import { findInactiveTabs } from '../utils/inactiveDetection';
 
-export type ViewMode = 'tabs' | 'duplicates' | 'inactives';
+export type ViewMode = 'tabs' | 'duplicates' | 'inactives' | 'saved';
 
 interface HeaderProps {
   searchQuery: string;
@@ -20,9 +20,10 @@ interface HeaderProps {
   viewMode: ViewMode;
   onViewChange: (view: ViewMode) => void;
   inactiveThresholdMs: number;
+  savedTabGroupCount: number;
 }
 
-const Header = ({ searchQuery, onSearchQueryChange, searchBarRef, allTabs, viewMode, onViewChange, inactiveThresholdMs }: HeaderProps) => {
+const Header = ({ searchQuery, onSearchQueryChange, searchBarRef, allTabs, viewMode, onViewChange, inactiveThresholdMs, savedTabGroupCount }: HeaderProps) => {
   const { selectedTabIds, removeTabsFromSelection } = useTabSelectionContext();
   const { setDeletingState } = useDeletionState();
   const { showToast } = useToast();
@@ -50,7 +51,7 @@ const Header = ({ searchQuery, onSearchQueryChange, searchBarRef, allTabs, viewM
     }
   };
 
-  const toggleView = (view: 'duplicates' | 'inactives') => {
+  const toggleView = (view: 'duplicates' | 'inactives' | 'saved') => {
     onViewChange(viewMode === view ? 'tabs' : view);
   };
 
@@ -80,6 +81,17 @@ const Header = ({ searchQuery, onSearchQueryChange, searchBarRef, allTabs, viewM
             </svg>
             {inactiveCount > 0 && (
               <div className="badge badge-sm badge-info absolute -top-1 -right-1">{inactiveCount}</div>
+            )}
+          </button>
+          <button
+            className={`btn btn-ghost relative ${viewMode === 'saved' ? 'btn-active' : ''}`}
+            onClick={() => toggleView('saved')}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
+              <path d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v11.25c0 .138-.111.25-.25.25h-.5a.25.25 0 0 1-.177-.073L8 9.81l-5.073 5.116A.25.25 0 0 1 2.75 15h-.5a.25.25 0 0 1-.25-.25V3.5Z" />
+            </svg>
+            {savedTabGroupCount > 0 && (
+              <div className="badge badge-sm badge-accent absolute -top-1 -right-1">{savedTabGroupCount}</div>
             )}
           </button>
           <button className="btn btn-ghost" onClick={handleCloseSelectedTabs} disabled={selectedTabIds.size === 0}>

--- a/src/components/InactivesView.tsx
+++ b/src/components/InactivesView.tsx
@@ -8,6 +8,7 @@ import {
   formatInactiveDuration,
   INACTIVE_THRESHOLD_PRESETS,
 } from '../utils/inactiveDetection';
+import type { SavedTabGroup } from '../types/savedTabs';
 
 const extractDomain = (url: string): string => {
   try {
@@ -23,9 +24,10 @@ interface InactivesViewProps {
   onBack: () => void;
   thresholdMs: number;
   onThresholdChange: (thresholdMs: number) => void;
+  onSaveAll: (tabs: chrome.tabs.Tab[]) => Promise<SavedTabGroup>;
 }
 
-const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThresholdChange }: InactivesViewProps) => {
+const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThresholdChange, onSaveAll }: InactivesViewProps) => {
   const { setDeletingState } = useDeletionState();
   const { focusActiveTab } = useTabFocusContext();
   const { showToast } = useToast();
@@ -55,6 +57,19 @@ const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThreshold
     }
   };
 
+  const handleSaveAll = async () => {
+    const ids = inactiveTabs.map(t => t.id!);
+    ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
+    try {
+      const group = await onSaveAll(inactiveTabs);
+      await chrome.tabs.remove(ids);
+      showToast(<Alert message={`Saved ${group.tabs.length} tab(s) and closed.`} variant="success" />);
+    } catch (error) {
+      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
+      showToast(<Alert message={`Failed to save tabs: ${error instanceof Error ? error.message : String(error)}`} />);
+    }
+  };
+
   return (
     <div className="mt-4">
       <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
@@ -80,9 +95,14 @@ const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThreshold
             ))}
           </select>
           {inactiveTabs.length > 0 && (
-            <button className="btn btn-sm btn-error" onClick={handleCloseAll}>
-              Close all ({inactiveTabs.length})
-            </button>
+            <>
+              <button className="btn btn-sm btn-warning" onClick={handleSaveAll}>
+                Save all ({inactiveTabs.length})
+              </button>
+              <button className="btn btn-sm btn-error" onClick={handleCloseAll}>
+                Close all ({inactiveTabs.length})
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/src/components/InactivesView.tsx
+++ b/src/components/InactivesView.tsx
@@ -60,13 +60,20 @@ const InactivesView = ({ allTabs, windowLabels, onBack, thresholdMs, onThreshold
   const handleSaveAll = async () => {
     const ids = inactiveTabs.map(t => t.id!);
     ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
+    let group;
     try {
-      const group = await onSaveAll(inactiveTabs);
+      group = await onSaveAll(inactiveTabs);
+    } catch (error) {
+      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
+      showToast(<Alert message={`Failed to save tabs: ${error instanceof Error ? error.message : String(error)}`} />);
+      return;
+    }
+    try {
       await chrome.tabs.remove(ids);
       showToast(<Alert message={`Saved ${group.tabs.length} tab(s) and closed.`} variant="success" />);
     } catch (error) {
       ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(<Alert message={`Failed to save tabs: ${error instanceof Error ? error.message : String(error)}`} />);
+      showToast(<Alert message={`Tabs saved but could not close them: ${error instanceof Error ? error.message : String(error)}`} />);
     }
   };
 

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -1,0 +1,137 @@
+import type { SavedTabGroup } from '../types/savedTabs';
+import { useToast } from './ToastProvider';
+import Alert from './Alert';
+import { formatGroupName } from '../utils/savedTabs';
+
+const extractDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '';
+  }
+};
+
+interface SavedTabsViewProps {
+  savedTabGroups: SavedTabGroup[];
+  onBack: () => void;
+  onRestoreGroup: (id: string) => Promise<void>;
+  onDeleteGroup: (id: string) => Promise<void>;
+  onClearAll: () => Promise<void>;
+}
+
+const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, onClearAll }: SavedTabsViewProps) => {
+  const { showToast } = useToast();
+
+  const handleRestoreGroup = async (id: string) => {
+    const group = savedTabGroups.find(g => g.id === id);
+    if (!group) return;
+    try {
+      await onRestoreGroup(id);
+      showToast(<Alert message={`Restored ${group.tabs.length} tab(s) in a new window.`} variant="success" />);
+    } catch (error) {
+      showToast(<Alert message={`Failed to restore: ${error instanceof Error ? error.message : String(error)}`} />);
+    }
+  };
+
+  const handleDeleteGroup = async (id: string) => {
+    try {
+      await onDeleteGroup(id);
+      showToast(<Alert message="Deleted saved group." variant="success" />);
+    } catch (error) {
+      showToast(<Alert message={`Failed to delete: ${error instanceof Error ? error.message : String(error)}`} />);
+    }
+  };
+
+  const handleClearAll = async () => {
+    try {
+      await onClearAll();
+      showToast(<Alert message="All saved groups cleared." variant="success" />);
+    } catch (error) {
+      showToast(<Alert message={`Failed to clear: ${error instanceof Error ? error.message : String(error)}`} />);
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-3 shrink-0">
+          <button className="btn btn-ghost btn-sm" onClick={onBack}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
+              <path fillRule="evenodd" d="M14 8a.75.75 0 0 1-.75.75H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 7.25h8.69A.75.75 0 0 1 14 8Z" clipRule="evenodd" />
+            </svg>
+            Back
+          </button>
+          <h2 className="text-lg font-bold whitespace-nowrap">Saved Tabs</h2>
+        </div>
+        {savedTabGroups.length > 0 && (
+          <button className="btn btn-sm btn-error btn-outline" onClick={handleClearAll}>
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {savedTabGroups.length === 0 ? (
+        <div className="text-center py-16 text-base-content/60">
+          <p className="text-lg">No saved tabs.</p>
+          <p className="text-sm mt-2">Use "Save all" in Inactive Tabs to save tabs here.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {savedTabGroups.map(group => (
+            <div key={group.id} className="card bg-base-200 shadow-sm">
+              <div className="card-body p-4">
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-bold">{formatGroupName(group.savedAt)}</h3>
+                    <span className="badge badge-sm badge-neutral">{group.tabs.length} tabs</span>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      className="btn btn-sm btn-success"
+                      onClick={() => handleRestoreGroup(group.id)}
+                    >
+                      Restore all
+                    </button>
+                    <button
+                      className="btn btn-sm btn-ghost btn-error"
+                      onClick={() => handleDeleteGroup(group.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                <ul className="list">
+                  {group.tabs.map((tab, i) => (
+                    <li key={i} className="list-row rounded-none items-center p-2 even:bg-base-300">
+                      <div>
+                        {tab.favIconUrl ? (
+                          <img className="size-4 object-contain" src={tab.favIconUrl} alt="" onError={e => ((e.target as HTMLImageElement).src = '')} />
+                        ) : (
+                          <span className="size-4 inline-block" />
+                        )}
+                      </div>
+                      <div className="list-col-grow min-w-0">
+                        <a
+                          className="truncate block hover:underline"
+                          href={tab.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          title={tab.title}
+                        >
+                          {tab.title || extractDomain(tab.url)}
+                        </a>
+                        <div className="text-xs text-base-content/50">{extractDomain(tab.url)}</div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SavedTabsView;

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -77,7 +77,7 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
       {savedTabGroups.length === 0 ? (
         <div className="text-center py-16 text-base-content/60">
           <p className="text-lg">No saved tabs.</p>
-          <p className="text-sm mt-2">Use "Save all" in Inactive Tabs to save tabs here.</p>
+          <p className="text-sm mt-2">Use &quot;Save all&quot; in Inactive Tabs to save tabs here.</p>
         </div>
       ) : (
         <div>

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -76,29 +76,34 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
           <p className="text-sm mt-2">Use "Save all" in Inactive Tabs to save tabs here.</p>
         </div>
       ) : (
-        <div className="flex flex-col gap-4">
+        <div>
           {savedTabGroups.map(group => (
-            <div key={group.id} className="card bg-base-200 shadow-sm">
-              <div className="card-body p-4">
-                <div className="flex items-center justify-between gap-3 mb-2">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-bold">{formatGroupName(group.savedAt)}</h3>
-                    <span className="badge badge-sm badge-neutral">{group.tabs.length} tabs</span>
-                  </div>
-                  <div className="flex gap-2 shrink-0">
-                    <button
-                      className="btn btn-sm btn-success"
-                      onClick={() => handleRestoreGroup(group.id)}
-                    >
-                      Restore all
-                    </button>
-                    <button
-                      className="btn btn-sm btn-ghost btn-error"
-                      onClick={() => handleDeleteGroup(group.id)}
-                    >
-                      Delete
-                    </button>
-                  </div>
+            <div key={group.id} className="collapse collapse-arrow bg-base-200 border-base-300 border rounded-lg mb-4">
+              <input
+                id={`saved-group-collapse-${group.id}`}
+                type="checkbox"
+                defaultChecked={true}
+              />
+              <div className="collapse-title">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold">{formatGroupName(group.savedAt)}</span>
+                  <span className="badge badge-sm badge-neutral">{group.tabs.length} tabs</span>
+                </div>
+              </div>
+              <div className="collapse-content">
+                <div className="flex gap-2 justify-end mb-3">
+                  <button
+                    className="btn btn-sm btn-success"
+                    onClick={() => handleRestoreGroup(group.id)}
+                  >
+                    Restore all
+                  </button>
+                  <button
+                    className="btn btn-sm btn-ghost btn-error"
+                    onClick={() => handleDeleteGroup(group.id)}
+                  >
+                    Delete
+                  </button>
                 </div>
                 <ul className="list">
                   {group.tabs.map((tab, i) => (

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import type { SavedTabGroup } from '../types/savedTabs';
 import { useToast } from './ToastProvider';
 import Alert from './Alert';
@@ -21,6 +22,9 @@ interface SavedTabsViewProps {
 
 const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, onClearAll }: SavedTabsViewProps) => {
   const { showToast } = useToast();
+  const deleteDialogRef = useRef<HTMLDialogElement>(null);
+  const clearAllDialogRef = useRef<HTMLDialogElement>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const handleRestoreGroup = async (id: string) => {
     const group = savedTabGroups.find(g => g.id === id);
@@ -64,7 +68,7 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
           <h2 className="text-lg font-bold whitespace-nowrap">Saved Tabs</h2>
         </div>
         {savedTabGroups.length > 0 && (
-          <button className="btn btn-sm btn-error btn-outline" onClick={handleClearAll}>
+          <button className="btn btn-sm btn-error btn-outline" onClick={() => clearAllDialogRef.current?.showModal()}>
             Clear all
           </button>
         )}
@@ -100,7 +104,10 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
                   </button>
                   <button
                     className="btn btn-sm btn-ghost btn-error"
-                    onClick={() => handleDeleteGroup(group.id)}
+                    onClick={() => {
+                      setPendingDeleteId(group.id);
+                      deleteDialogRef.current?.showModal();
+                    }}
                   >
                     Delete
                   </button>
@@ -135,6 +142,46 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
           ))}
         </div>
       )}
+      <dialog ref={deleteDialogRef} className="modal">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg">Delete saved group?</h3>
+          <p className="py-4 text-base-content/70">This cannot be undone.</p>
+          <div className="modal-action">
+            <form method="dialog" className="flex gap-2">
+              <button className="btn btn-sm">Cancel</button>
+              <button
+                className="btn btn-sm btn-error"
+                onClick={() => {
+                  if (pendingDeleteId) handleDeleteGroup(pendingDeleteId);
+                }}
+              >
+                Delete
+              </button>
+            </form>
+          </div>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
+
+      <dialog ref={clearAllDialogRef} className="modal">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg">Clear all saved groups?</h3>
+          <p className="py-4 text-base-content/70">This cannot be undone.</p>
+          <div className="modal-action">
+            <form method="dialog" className="flex gap-2">
+              <button className="btn btn-sm">Cancel</button>
+              <button className="btn btn-sm btn-error" onClick={handleClearAll}>
+                Clear all
+              </button>
+            </form>
+          </div>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
     </div>
   );
 };

--- a/src/hooks/useSavedTabs.ts
+++ b/src/hooks/useSavedTabs.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { SavedTabGroup } from '../types/savedTabs';
+import {
+  loadSavedTabGroups,
+  addSavedTabGroup,
+  deleteSavedTabGroup,
+  clearAllSavedTabGroups,
+} from '../utils/savedTabs';
+
+export function useSavedTabs() {
+  const [savedTabGroups, setSavedTabGroups] = useState<SavedTabGroup[]>([]);
+
+  useEffect(() => {
+    loadSavedTabGroups().then(setSavedTabGroups);
+  }, []);
+
+  const saveInactiveTabs = useCallback(async (tabs: chrome.tabs.Tab[]): Promise<SavedTabGroup> => {
+    const group = await addSavedTabGroup(tabs);
+    setSavedTabGroups(prev => [group, ...prev]);
+    return group;
+  }, []);
+
+  const restoreGroup = useCallback(
+    async (id: string): Promise<void> => {
+      const group = savedTabGroups.find(g => g.id === id);
+      if (!group) return;
+      await chrome.windows.create({ url: group.tabs.map(t => t.url) });
+      await deleteSavedTabGroup(id);
+      setSavedTabGroups(prev => prev.filter(g => g.id !== id));
+    },
+    [savedTabGroups]
+  );
+
+  const deleteGroup = useCallback(async (id: string): Promise<void> => {
+    await deleteSavedTabGroup(id);
+    setSavedTabGroups(prev => prev.filter(g => g.id !== id));
+  }, []);
+
+  const clearAll = useCallback(async (): Promise<void> => {
+    await clearAllSavedTabGroups();
+    setSavedTabGroups([]);
+  }, []);
+
+  return { savedTabGroups, saveInactiveTabs, restoreGroup, deleteGroup, clearAll };
+}

--- a/src/types/savedTabs.ts
+++ b/src/types/savedTabs.ts
@@ -1,0 +1,11 @@
+export interface SavedTab {
+  title: string;
+  url: string;
+  favIconUrl?: string;
+}
+
+export interface SavedTabGroup {
+  id: string;
+  savedAt: number;
+  tabs: SavedTab[];
+}

--- a/src/utils/savedTabs.test.ts
+++ b/src/utils/savedTabs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatGroupName, loadSavedTabGroups, addSavedTabGroup, deleteSavedTabGroup, clearAllSavedTabGroups } from './savedTabs';
+
+// --- formatGroupName (pure function) ---
+
+describe('formatGroupName', () => {
+  it('formats a timestamp as "Mon DD · HH:MM"', () => {
+    // 2026-03-30 14:32:00 UTC+9 (JST) → depends on locale, so use a known timestamp
+    // Use a fixed date: 2026-01-05 09:07:00 local time
+    const date = new Date(2026, 0, 5, 9, 7, 0); // Jan 5, 09:07
+    const result = formatGroupName(date.getTime());
+    expect(result).toBe('Jan 5 · 09:07');
+  });
+
+  it('zero-pads hours and minutes', () => {
+    const date = new Date(2026, 5, 3, 8, 4, 0); // Jun 3, 08:04
+    const result = formatGroupName(date.getTime());
+    expect(result).toBe('Jun 3 · 08:04');
+  });
+
+  it('formats double-digit day correctly', () => {
+    const date = new Date(2026, 11, 25, 23, 59, 0); // Dec 25, 23:59
+    const result = formatGroupName(date.getTime());
+    expect(result).toBe('Dec 25 · 23:59');
+  });
+});
+
+// --- Storage CRUD functions (chrome.storage.local mock) ---
+
+const mockStorage: Record<string, unknown> = {};
+
+vi.stubGlobal('chrome', {
+  storage: {
+    local: {
+      get: vi.fn(async (key: string) => ({ [key]: mockStorage[key] })),
+      set: vi.fn(async (obj: Record<string, unknown>) => {
+        Object.assign(mockStorage, obj);
+      }),
+      remove: vi.fn(async (key: string) => {
+        delete mockStorage[key];
+      }),
+    },
+  },
+  randomUUID: vi.fn(() => 'test-uuid'),
+});
+
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' });
+
+const STORAGE_KEY = 'lazycluster.savedTabGroups';
+
+beforeEach(() => {
+  Object.keys(mockStorage).forEach(k => delete mockStorage[k]);
+  vi.clearAllMocks();
+});
+
+describe('loadSavedTabGroups', () => {
+  it('returns empty array when storage is empty', async () => {
+    const result = await loadSavedTabGroups();
+    expect(result).toEqual([]);
+  });
+
+  it('returns stored groups', async () => {
+    const groups = [{ id: '1', savedAt: 1000, tabs: [] }];
+    mockStorage[STORAGE_KEY] = groups;
+    const result = await loadSavedTabGroups();
+    expect(result).toEqual(groups);
+  });
+});
+
+describe('addSavedTabGroup', () => {
+  it('prepends new group to existing groups', async () => {
+    const existing = [{ id: 'old', savedAt: 1000, tabs: [] }];
+    mockStorage[STORAGE_KEY] = existing;
+
+    const tabs = [
+      { url: 'https://example.com', title: 'Example', favIconUrl: undefined } as chrome.tabs.Tab,
+    ];
+    const group = await addSavedTabGroup(tabs);
+
+    expect(group.tabs).toHaveLength(1);
+    expect(group.tabs[0].url).toBe('https://example.com');
+
+    const stored = mockStorage[STORAGE_KEY] as typeof existing;
+    expect(stored[0].id).toBe('test-uuid');
+    expect(stored[1].id).toBe('old');
+  });
+
+  it('filters out tabs without url', async () => {
+    const tabs = [
+      { url: 'https://a.com', title: 'A' } as chrome.tabs.Tab,
+      { url: undefined, title: 'No URL' } as chrome.tabs.Tab,
+    ];
+    const group = await addSavedTabGroup(tabs);
+    expect(group.tabs).toHaveLength(1);
+  });
+});
+
+describe('deleteSavedTabGroup', () => {
+  it('removes group with matching id', async () => {
+    mockStorage[STORAGE_KEY] = [
+      { id: 'a', savedAt: 1000, tabs: [] },
+      { id: 'b', savedAt: 2000, tabs: [] },
+    ];
+    await deleteSavedTabGroup('a');
+    const stored = mockStorage[STORAGE_KEY] as Array<{ id: string }>;
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('b');
+  });
+});
+
+describe('clearAllSavedTabGroups', () => {
+  it('removes the storage key', async () => {
+    mockStorage[STORAGE_KEY] = [{ id: 'a', savedAt: 1000, tabs: [] }];
+    await clearAllSavedTabGroups();
+    expect(mockStorage[STORAGE_KEY]).toBeUndefined();
+  });
+});

--- a/src/utils/savedTabs.test.ts
+++ b/src/utils/savedTabs.test.ts
@@ -41,7 +41,6 @@ vi.stubGlobal('chrome', {
       }),
     },
   },
-  randomUUID: vi.fn(() => 'test-uuid'),
 });
 
 vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' });

--- a/src/utils/savedTabs.ts
+++ b/src/utils/savedTabs.ts
@@ -1,0 +1,43 @@
+import type { SavedTabGroup } from '../types/savedTabs';
+
+const STORAGE_KEY = 'lazycluster.savedTabGroups';
+
+export async function loadSavedTabGroups(): Promise<SavedTabGroup[]> {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  return (result[STORAGE_KEY] as SavedTabGroup[]) ?? [];
+}
+
+export async function saveSavedTabGroups(groups: SavedTabGroup[]): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: groups });
+}
+
+export async function addSavedTabGroup(tabs: chrome.tabs.Tab[]): Promise<SavedTabGroup> {
+  const group: SavedTabGroup = {
+    id: crypto.randomUUID(),
+    savedAt: Date.now(),
+    tabs: tabs
+      .filter(t => t.url)
+      .map(t => ({ title: t.title ?? t.url ?? '', url: t.url!, favIconUrl: t.favIconUrl })),
+  };
+  const existing = await loadSavedTabGroups();
+  await saveSavedTabGroups([group, ...existing]);
+  return group;
+}
+
+export async function deleteSavedTabGroup(id: string): Promise<void> {
+  const existing = await loadSavedTabGroups();
+  await saveSavedTabGroups(existing.filter(g => g.id !== id));
+}
+
+export async function clearAllSavedTabGroups(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}
+
+export function formatGroupName(savedAt: number): string {
+  const date = new Date(savedAt);
+  const month = date.toLocaleString('en-US', { month: 'short' });
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${month} ${day} · ${hours}:${minutes}`;
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   manifest: ({ mode }) => ({
     name: mode === 'development' ? 'lazycluster-dev' : 'lazycluster',
-    permissions: ['tabs', 'tabGroups'],
+    permissions: ['tabs', 'tabGroups', 'storage'],
     description: 'Organize Chrome tabs & windows. Enjoy comfortable browsing & boost productivity.',
     content_security_policy: {
       extension_pages: "script-src 'self'; object-src 'self'",


### PR DESCRIPTION
## Summary

- Add Save Tabs feature that saves inactive tabs to `chrome.storage` and closes them (OneTab-like stash)
- Add `SavedTabsView` with collapsible groups, Restore all, Delete, and Clear all actions
- Add confirmation dialogs for destructive actions (Delete / Clear all) since saved data cannot be recovered from browser history

## Changes

- `src/components/SavedTabsView.tsx` — new view with collapsible groups and confirmation dialogs
- `src/hooks/useSavedTabs.ts` — hook managing `chrome.storage` read/write for saved tab groups
- `src/types/savedTabs.ts` — `SavedTabGroup` type definition
- `src/utils/savedTabs.ts` + `savedTabs.test.ts` — pure utilities with unit tests
- `src/components/InactivesView.tsx` — "Save all" button that saves + closes inactive tabs
- `entrypoints/manager/App.tsx` — view routing for Saved Tabs
- `src/components/Header.tsx` — navigation entry point to Saved Tabs view

## Test plan

- [x] "Save all" in Inactive Tabs saves groups and closes the tabs
- [x] Saved Tabs view shows collapsible groups with tab count badge
- [x] "Restore all" reopens tabs in a new window
- [x] "Delete" button shows confirmation dialog; Cancel keeps data, confirm deletes the group
- [x] "Clear all" button shows confirmation dialog; Cancel keeps data, confirm deletes all groups
- [x] Backdrop click on dialog closes it without deleting
- [x] `npm run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)