### PR TITLE
test(savedTabs): decouple tests from STORAGE_KEY internal detail

### DIFF
--- a/src/utils/savedTabs.test.ts
+++ b/src/utils/savedTabs.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { formatGroupName, loadSavedTabGroups, addSavedTabGroup, deleteSavedTabGroup, clearAllSavedTabGroups } from './savedTabs';
+import {
+  formatGroupName,
+  loadSavedTabGroups,
+  saveSavedTabGroups,
+  addSavedTabGroup,
+  deleteSavedTabGroup,
+  clearAllSavedTabGroups,
+} from './savedTabs';
+import type { SavedTabGroup } from '../types/savedTabs';
 
 // --- formatGroupName (pure function) ---
 
@@ -45,8 +53,6 @@ vi.stubGlobal('chrome', {
 
 vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' });
 
-const STORAGE_KEY = 'lazycluster.savedTabGroups';
-
 beforeEach(() => {
   Object.keys(mockStorage).forEach(k => delete mockStorage[k]);
   vi.clearAllMocks();
@@ -59,8 +65,8 @@ describe('loadSavedTabGroups', () => {
   });
 
   it('returns stored groups', async () => {
-    const groups = [{ id: '1', savedAt: 1000, tabs: [] }];
-    mockStorage[STORAGE_KEY] = groups;
+    const groups: SavedTabGroup[] = [{ id: '1', savedAt: 1000, tabs: [] }];
+    await saveSavedTabGroups(groups);
     const result = await loadSavedTabGroups();
     expect(result).toEqual(groups);
   });
@@ -68,8 +74,8 @@ describe('loadSavedTabGroups', () => {
 
 describe('addSavedTabGroup', () => {
   it('prepends new group to existing groups', async () => {
-    const existing = [{ id: 'old', savedAt: 1000, tabs: [] }];
-    mockStorage[STORAGE_KEY] = existing;
+    const existing: SavedTabGroup[] = [{ id: 'old', savedAt: 1000, tabs: [] }];
+    await saveSavedTabGroups(existing);
 
     const tabs = [
       { url: 'https://example.com', title: 'Example', favIconUrl: undefined } as chrome.tabs.Tab,
@@ -79,7 +85,7 @@ describe('addSavedTabGroup', () => {
     expect(group.tabs).toHaveLength(1);
     expect(group.tabs[0].url).toBe('https://example.com');
 
-    const stored = mockStorage[STORAGE_KEY] as typeof existing;
+    const stored = await loadSavedTabGroups();
     expect(stored[0].id).toBe('test-uuid');
     expect(stored[1].id).toBe('old');
   });
@@ -96,21 +102,21 @@ describe('addSavedTabGroup', () => {
 
 describe('deleteSavedTabGroup', () => {
   it('removes group with matching id', async () => {
-    mockStorage[STORAGE_KEY] = [
+    await saveSavedTabGroups([
       { id: 'a', savedAt: 1000, tabs: [] },
       { id: 'b', savedAt: 2000, tabs: [] },
-    ];
+    ]);
     await deleteSavedTabGroup('a');
-    const stored = mockStorage[STORAGE_KEY] as Array<{ id: string }>;
+    const stored = await loadSavedTabGroups();
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe('b');
   });
 });
 
 describe('clearAllSavedTabGroups', () => {
-  it('removes the storage key', async () => {
-    mockStorage[STORAGE_KEY] = [{ id: 'a', savedAt: 1000, tabs: [] }];
+  it('removes all stored groups', async () => {
+    await saveSavedTabGroups([{ id: 'a', savedAt: 1000, tabs: [] }]);
     await clearAllSavedTabGroups();
-    expect(mockStorage[STORAGE_KEY]).toBeUndefined();
+    expect(await loadSavedTabGroups()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Replace direct `mockStorage[STORAGE_KEY]` access (8 sites) with public API calls (`saveSavedTabGroups` / `loadSavedTabGroups`)
- Remove the duplicated `STORAGE_KEY` constant from the test file
- Tests now verify observable round-trip behavior, not the internal storage key name

## Why
Per the PR #232 review feedback, `savedTabs.test.ts` was redefining `STORAGE_KEY` to reach into the chrome storage mock. The straightforward fix — `export STORAGE_KEY` from `savedTabs.ts` and import it in the test — was rejected because:

1. **`STORAGE_KEY` is an implementation detail**, not part of the API contract.
2. **Sharing the constant hides bugs**: a typo in the key name would change both producer and consumer simultaneously, so tests would still pass while a real migration would lose data.
3. **Tests should describe behavior, not internals** — the contract being verified is "what `addSavedTabGroup` writes is what `loadSavedTabGroups` returns", not "the internal key name matches".

See plan: `~/.claude/plans/lazycluster-savedtabs-test-decoupling.md` (kept out of this PR scope per project convention).

## What changed
- `STORAGE_KEY` const definition removed from test file
- `import` updated to add `saveSavedTabGroups` and the `SavedTabGroup` type
- `clearAllSavedTabGroups` test renamed `removes the storage key` → `removes all stored groups` (observable behavior)

The chrome storage mock itself is untouched — `mockStorage` still backs the stubbed `chrome.storage.local`. The change is that *tests* no longer reach in with the internal key.

## Test plan
- [x] `npm run test:unit` — 189 tests pass (savedTabs: 9 tests)
- [x] `npm run compile` — no type errors
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)