### PR TITLE
ci: deploy GitHub Pages only when docs/ changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Add a dedicated `pages.yml` Actions workflow that deploys `docs/` (the privacy policy page) to GitHub Pages only when a push to `main` touches `docs/**`
- Previously Pages used the classic "Deploy from a branch" source, which redeploys on *every* push to `main` regardless of whether `docs/` changed

## Required manual step (cannot be done via this PR)
After merging, switch **Settings → Pages → Build and deployment → Source** from "Deploy from a branch" to **"GitHub Actions"**. Until that switch happens, the classic mechanism keeps deploying on every push in addition to this workflow.

## Test plan
- [ ] Merge this PR, then switch Pages source to "GitHub Actions" in repo settings
- [ ] Push a change to `docs/index.html` on `main` → confirm the `Deploy Pages` workflow runs and the site updates
- [ ] Push a change to an unrelated file (e.g. `README.md`) on `main` → confirm the `Deploy Pages` workflow does NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)