### PR TITLE
refactor: dedupe extractDomain, remove dead code, a11y fixes

### DIFF
--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -23,7 +23,6 @@ import './style.css';
 interface BackgroundMessage {
   type: 'UPDATE_TABS' | 'BACKGROUND_INITIALIZED' | 'REQUEST_INITIAL_DATA'; // Known types
   tabs?: chrome.tabs.Tab[]; // Make tabs optional as it's not always present
-  payload?: unknown; // Keep payload flexible if needed
 }
 
 const getViewFromHash = (): ViewMode => {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -15,7 +15,11 @@ const App = () => {
     const allTabs = await chrome.tabs.query({ url: managerUrl });
     const tabsInOtherWindows = allTabs.filter(tab => tab.windowId !== currentWindowId);
     if (tabsInOtherWindows.length > 0) {
-      await Promise.all(tabsInOtherWindows.map(tab => chrome.tabs.remove(tab.id!)));
+      try {
+        await Promise.all(tabsInOtherWindows.map(tab => chrome.tabs.remove(tab.id!)));
+      } catch (error) {
+        console.error('Failed to remove manager tabs in other windows:', error);
+      }
       return true;
     }
     return false;
@@ -39,15 +43,10 @@ const App = () => {
   }, []);
 
   return (
-    // Apply styles to center content and set min height/width, mimicking original body styles
     <div className="flex items-center justify-center min-h-screen min-w-[320px]">
-      {/* Apply max-width, auto margin, padding, and text alignment, mimicking original #root styles */}
       <div className="max-w-screen-xl mx-auto p-8 text-center">
-        {/* Center the image and add some margin below it */}
         <img src="/icon/48.png" className="inline-block mb-4" />
-        {/* Apply heading styles */}
         <h1 className="text-5xl leading-tight">lazycluster</h1>
-        {/* Apply card styles with padding */}
         <div className="card p-8">
           <button className="btn btn-secondary" onClick={openWindowManager}>
             Window Manager

--- a/src/components/DuplicatesView.tsx
+++ b/src/components/DuplicatesView.tsx
@@ -10,14 +10,7 @@ import {
   getTabsToClose,
   type DuplicateMatchMode,
 } from '../utils/duplicateDetection';
-
-const extractDomain = (url: string): string => {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '';
-  }
-};
+import { extractDomain } from '../utils/url';
 
 interface DuplicatesViewProps {
   allTabs: chrome.tabs.Tab[];
@@ -166,12 +159,13 @@ const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) 
                           </td>
                           <td className="text-base-content/60 truncate">{extractDomain(tab.url || '')}</td>
                           <td className="text-base-content/60">
-                            <a
-                              className="cursor-pointer hover:underline"
+                            <button
+                              type="button"
+                              className="link link-hover cursor-pointer"
                               onClick={() => chrome.windows.update(tab.windowId, { focused: true })}
                             >
                               {windowLabels.get(tab.windowId) ?? `W${tab.windowId}`}
-                            </a>
+                            </button>
                           </td>
                         </tr>
                       ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { RefObject } from 'react';
 import SearchBar from './SearchBar';
 import ThemeSwitcher from './ThemeSwitcher';
 import TabCountBadge from './TabCountBadge';
@@ -15,7 +15,7 @@ export type ViewMode = 'tabs' | 'duplicates' | 'inactives' | 'saved';
 interface HeaderProps {
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
-  searchBarRef: React.RefObject<HTMLInputElement | null>;
+  searchBarRef: RefObject<HTMLInputElement | null>;
   allTabs: chrome.tabs.Tab[];
   viewMode: ViewMode;
   onViewChange: (view: ViewMode) => void;

--- a/src/components/InactivesView.tsx
+++ b/src/components/InactivesView.tsx
@@ -10,14 +10,7 @@ import {
   INACTIVE_THRESHOLD_PRESETS,
 } from '../utils/inactiveDetection';
 import type { SavedTabGroup } from '../types/savedTabs';
-
-const extractDomain = (url: string): string => {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '';
-  }
-};
+import { extractDomain } from '../utils/url';
 
 interface InactivesViewProps {
   allTabs: chrome.tabs.Tab[];
@@ -170,12 +163,13 @@ const InactivesView = ({
                   </a>
                   <div className="text-xs text-base-content/50">
                     {extractDomain(tab.url || '')} ·{' '}
-                    <a
-                      className="cursor-pointer hover:underline"
+                    <button
+                      type="button"
+                      className="link link-hover cursor-pointer"
                       onClick={() => chrome.windows.update(tab.windowId, { focused: true })}
                     >
                       {windowLabels.get(tab.windowId) ?? `W${tab.windowId}`}
-                    </a>{' '}
+                    </button>{' '}
                     · {tab.lastAccessed ? formatInactiveDuration(tab.lastAccessed) : ''}
                   </div>
                 </div>

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -4,14 +4,7 @@ import { useToast } from './ToastProvider';
 import Alert from './Alert';
 import FaviconImage from './FaviconImage';
 import { formatGroupName } from '../utils/savedTabs';
-
-const extractDomain = (url: string): string => {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '';
-  }
-};
+import { extractDomain } from '../utils/url';
 
 interface SavedTabsViewProps {
   savedTabGroups: SavedTabGroup[];
@@ -112,7 +105,7 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
                 </div>
                 <ul className="list">
                   {group.tabs.map((tab, i) => (
-                    <li key={i} className="list-row rounded-none items-center p-2 even:bg-base-300">
+                    <li key={`${tab.url}-${i}`} className="list-row rounded-none items-center p-2 even:bg-base-300">
                       <div>
                         <FaviconImage src={tab.favIconUrl} />
                       </div>

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -11,14 +11,7 @@ import Alert from './Alert';
 import FaviconImage from './FaviconImage';
 import { getTabGroupBorderColorClass } from '../utils/tabGroupColors';
 import { getTabIdsInRangeForWindow } from '../utils/dragSelection';
-
-const extractDomain = (url: string): string => {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '';
-  }
-};
+import { extractDomain } from '../utils/url';
 
 interface TabItemProps {
   tab: chrome.tabs.Tab;

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
+import type { KeyboardEvent } from 'react';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import TabItem from './TabItem';
 
@@ -12,7 +13,7 @@ interface TabListProps {
 const TabList = ({ tabs, isFiltered = false, overId, dropPosition }: TabListProps) => {
   const listRef = useRef<HTMLUListElement>(null);
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
     const activeElement = document.activeElement;
     if (!activeElement || !listRef.current?.contains(activeElement)) {
       return;

--- a/src/components/WindowActions.tsx
+++ b/src/components/WindowActions.tsx
@@ -13,7 +13,6 @@ const extractTabIds = (tabs: chrome.tabs.Tab[]): number[] => {
   return tabs.map(tab => tab.id).filter((id): id is number => id !== undefined);
 };
 
-// visibleTabs is used to determine the checked state of the bulk select checkbox
 const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
   const { selectedTabIds, addTabsToSelection, removeTabsFromSelection } = useTabSelectionContext();
   const { setDeletingState } = useDeletionState();
@@ -89,37 +88,35 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
   const selectedCountInWindow = countSelectedIds(visibleTabIds, selectedTabIds);
 
   return (
-    <>
-      <ul className="list shadow-md">
-        <li className="list-row p-2 items-center rounded-none gap-1.5 border-l-[3px] border-l-transparent">
-          <div>
-            <input
-              id={`bulk-select-tabs-on-window-${windowId}`}
-              className="checkbox checkbox-xs"
-              type="checkbox"
-              onChange={handleBulkSelectChange}
-              checked={shouldBulkSelectBeChecked(visibleTabIds, selectedTabIds)}
-            />
-          </div>
-          <div className="list-grow">
-            <button className="btn btn-link btn-xs" onClick={handleFocusWindow}>
-              Focus
-            </button>
-            <button className="btn btn-link btn-xs" onClick={handleCloseWindow}>
-              Close Window
-            </button>
-            <button
-              className="btn btn-link btn-xs"
-              onClick={handleCloseTabsInWindow}
-              disabled={shouldCloseTabsBeDisabled(visibleTabIds, selectedTabIds)}
-            >
-              Close Tabs
-            </button>
-            {selectedCountInWindow > 0 && `(${selectedCountInWindow})`}
-          </div>
-        </li>
-      </ul>
-    </>
+    <ul className="list shadow-md">
+      <li className="list-row p-2 items-center rounded-none gap-1.5 border-l-[3px] border-l-transparent">
+        <div>
+          <input
+            id={`bulk-select-tabs-on-window-${windowId}`}
+            className="checkbox checkbox-xs"
+            type="checkbox"
+            onChange={handleBulkSelectChange}
+            checked={shouldBulkSelectBeChecked(visibleTabIds, selectedTabIds)}
+          />
+        </div>
+        <div className="list-grow">
+          <button className="btn btn-link btn-xs" onClick={handleFocusWindow}>
+            Focus
+          </button>
+          <button className="btn btn-link btn-xs" onClick={handleCloseWindow}>
+            Close Window
+          </button>
+          <button
+            className="btn btn-link btn-xs"
+            onClick={handleCloseTabsInWindow}
+            disabled={shouldCloseTabsBeDisabled(visibleTabIds, selectedTabIds)}
+          >
+            Close Tabs
+          </button>
+          {selectedCountInWindow > 0 && `(${selectedCountInWindow})`}
+        </div>
+      </li>
+    </ul>
   );
 };
 

--- a/src/components/WindowGroupList.tsx
+++ b/src/components/WindowGroupList.tsx
@@ -463,29 +463,23 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
 
       {/* DragOverlay shows clone of dragged item with optional selection badge */}
       <DragOverlay>
-        {activeTab
-          ? (() => {
-              return (
-                <div className="relative">
-                  <ul className="list shadow-md">
-                    <TabItem
-                      tab={activeTab}
-                      isFiltered={false}
-                      index={activeTabWindowTabs.findIndex(t => t.id === activeId)}
-                      windowId={activeTab.windowId!}
-                      tabs={activeTabWindowTabs}
-                    />
-                  </ul>
-                  {/* Show badge with selection count during multi-drag */}
-                  {dragSelectedTabIds.has(activeId!) && dragSelectedTabIds.size > 1 && (
-                    <div className="absolute -top-2 -right-2 badge badge-sm badge-accent">
-                      {dragSelectedTabIds.size}
-                    </div>
-                  )}
-                </div>
-              );
-            })()
-          : null}
+        {activeTab ? (
+          <div className="relative">
+            <ul className="list shadow-md">
+              <TabItem
+                tab={activeTab}
+                isFiltered={false}
+                index={activeTabWindowTabs.findIndex(t => t.id === activeId)}
+                windowId={activeTab.windowId!}
+                tabs={activeTabWindowTabs}
+              />
+            </ul>
+            {/* Show badge with selection count during multi-drag */}
+            {dragSelectedTabIds.has(activeId!) && dragSelectedTabIds.size > 1 && (
+              <div className="absolute -top-2 -right-2 badge badge-sm badge-accent">{dragSelectedTabIds.size}</div>
+            )}
+          </div>
+        ) : null}
       </DragOverlay>
     </DndContext>
   );

--- a/src/hooks/useBackgroundConnection.ts
+++ b/src/hooks/useBackgroundConnection.ts
@@ -7,7 +7,6 @@ import { devLog } from '../utils/devLog';
 // Let's assume a base message structure for now.
 interface BaseMessage {
   type: string;
-  payload?: unknown; // Use unknown instead of any for better type safety
 }
 
 type MessageHandler<T extends BaseMessage> = (message: T) => void;
@@ -43,13 +42,6 @@ export const useBackgroundConnection = <T extends BaseMessage>(portName: string,
     devLog(`${new Date()} - Attempting to connect to background script with port name: ${portName}`);
     try {
       portRef.current = chrome.runtime.connect({ name: portName });
-
-      if (chrome.runtime.lastError) {
-        console.error(`${new Date()} - Connection failed:`, chrome.runtime.lastError.message);
-        portRef.current = null;
-        scheduleReconnect();
-        return;
-      }
 
       devLog(`${new Date()} - Successfully connected to background script.`);
       setIsConnected(true); // Update connection status

--- a/src/utils/backoff.test.ts
+++ b/src/utils/backoff.test.ts
@@ -6,11 +6,11 @@ describe('calculateBackoff', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns correct delay with default options (attempt=5)', () => {
+  it('returns correct delay for attempt=5 with default intervals', () => {
     // calculatedDelay = 30000 * 2^5 = 960000
     // delay = 960000/2 + (Math.random() * 960000)/2
     vi.spyOn(Math, 'random').mockReturnValue(0.5);
-    const delay = calculateBackoff();
+    const delay = calculateBackoff({ attempt: 5 });
     // 960000/2 = 480000, (0.5*960000)/2 = 240000, total = 720000
     expect(delay).toBe(720000);
   });

--- a/src/utils/backoff.ts
+++ b/src/utils/backoff.ts
@@ -3,7 +3,7 @@
  * Accepts an options object for flexibility and clarity.
  *
  * @param options - Configuration for backoff calculation
- *   - attempt: The current attempt number (0-based, default: 5)
+ *   - attempt: The current attempt number (0-based, required)
  *   - baseInterval: The base interval in ms (default: 30000)
  *   - factor: The exponential factor (default: 2)
  *   - maxRetries: Maximum allowed attempts (default: 7)
@@ -13,18 +13,18 @@
  * Why use an options object? → Named parameters improve readability and extensibility.
  */
 export interface CalculateBackoffOptions {
-  attempt?: number;
+  attempt: number;
   baseInterval?: number;
   factor?: number;
   maxRetries?: number;
 }
 
 export const calculateBackoff = ({
-  attempt = 5,
+  attempt,
   baseInterval = 30000,
   factor = 2,
   maxRetries = 7,
-}: CalculateBackoffOptions = {}): number | -1 => {
+}: CalculateBackoffOptions): number | -1 => {
   if (attempt > maxRetries) {
     return -1; // Maximum retries exceeded
   }

--- a/src/utils/devLog.ts
+++ b/src/utils/devLog.ts
@@ -2,8 +2,7 @@
  * Logs messages to the console only in development mode.
  * @param args - The arguments to log.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const devLog = (...args: any[]): void => {
+export const devLog = (...args: unknown[]): void => {
   if (import.meta.env.MODE === 'development') {
     console.log(...args);
   }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { extractDomain } from './url';
+
+describe('extractDomain', () => {
+  it('returns the hostname for a valid http URL', () => {
+    expect(extractDomain('http://example.com/path?query=1')).toBe('example.com');
+  });
+
+  it('returns the hostname for a valid https URL', () => {
+    expect(extractDomain('https://sub.example.co.jp/page#hash')).toBe('sub.example.co.jp');
+  });
+
+  it('returns an empty string for an invalid URL string', () => {
+    expect(extractDomain('not a url')).toBe('');
+  });
+
+  it('returns an empty string for an empty string', () => {
+    expect(extractDomain('')).toBe('');
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,11 @@
+/**
+ * Extracts the hostname from a URL string.
+ * Returns an empty string when the URL is invalid.
+ */
+export const extractDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '';
+  }
+};


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup batch (+107 / −121). Follows up #268 — the diff is pure cleanup since formatting was already landed there.

### Deduplication
- `extractDomain` existed as 4 byte-identical local copies (TabItem, DuplicatesView, InactivesView, SavedTabsView) → extracted to `src/utils/url.ts` with unit tests

### Dead code removal
- `useBackgroundConnection`: post-`connect()` `chrome.runtime.lastError` check never fires (connect is synchronous; failures surface via `onDisconnect`, which already reads `lastError`)
- Unused `payload?: unknown` field on port message interfaces (both sides)
- Pointless IIFE in the DragOverlay render, redundant fragment in WindowActions
- `backoff`: removed the misleading `attempt = 5` default (sole caller always passes it)
- `devLog`: `any[]` → `unknown[]`, dropped the eslint-disable
- Dropped React default imports in favor of type-only imports (TabList, Header)

### Behavior-adjacent (intentional)
- **a11y**: window-focus actions in DuplicatesView/InactivesView were `<a onClick>` without `href` (not keyboard-focusable) → `<button type="button">` with link styling
- **popup**: tab removal wrapped in try/catch — the manager still opens if closing other-window manager tabs fails (previously the whole flow aborted)
- SavedTabsView list key: bare index → `url-index` composite

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` 201 tests ✅ / `prettier --check` ✅ / `npm run build` ✅
- E2E: 46/47 passed; the 1 failure was the known flaky "timeout while setting up context" pattern and passed on isolated retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)