### PR TITLE
refactor: share typed message protocol between background and manager

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,9 @@
 import { devLog } from '../src/utils/devLog';
+import {
+  MANAGER_PORT_NAME,
+  type BackgroundToManagerMessage,
+  type ManagerToBackgroundMessage,
+} from '../src/types/messages';
 
 export default defineBackground(() => {
   devLog('Hello background!', { id: chrome.runtime.id });
@@ -38,7 +43,7 @@ export default defineBackground(() => {
   const updateTabs = async (port: chrome.runtime.Port) => {
     try {
       const tabs = await getTabs();
-      port.postMessage({ type: 'UPDATE_TABS', tabs });
+      port.postMessage({ type: 'UPDATE_TABS', tabs } satisfies BackgroundToManagerMessage);
     } catch (error) {
       console.error('Failed to update tabs:', error);
     }
@@ -108,8 +113,8 @@ export default defineBackground(() => {
     if (import.meta.env.MODE === 'development') {
       console.dir(p);
     }
-    if (p.name === 'manager') {
-      port = p as chrome.runtime.Port;
+    if (p.name === MANAGER_PORT_NAME) {
+      port = p;
       port.onDisconnect.addListener(() => {
         devLog(`${new Date()} - onDisconnect`);
         if (import.meta.env.MODE === 'development') {
@@ -118,13 +123,13 @@ export default defineBackground(() => {
         port = null;
       });
 
-      port.onMessage.addListener(async message => {
+      port.onMessage.addListener(async (message: ManagerToBackgroundMessage) => {
         if (message.type === 'REQUEST_INITIAL_DATA') {
           try {
             const tabs = await getTabs();
             if (port) {
-              port.postMessage({ type: 'UPDATE_TABS', tabs });
-              port.postMessage({ type: 'BACKGROUND_INITIALIZED' });
+              port.postMessage({ type: 'UPDATE_TABS', tabs } satisfies BackgroundToManagerMessage);
+              port.postMessage({ type: 'BACKGROUND_INITIALIZED' } satisfies BackgroundToManagerMessage);
             }
           } catch (error) {
             console.error('Failed to send initial data:', error);
@@ -135,12 +140,4 @@ export default defineBackground(() => {
   };
 
   chrome.runtime.onConnect.addListener(connect);
-
-  chrome.runtime.onMessage.addListener((request: { action?: string; tabId?: number }) => {
-    if (request.action === 'closeTab' && request.tabId) {
-      chrome.tabs.remove(request.tabId).catch(error => {
-        console.error(`Failed to close tab ${request.tabId}:`, error);
-      });
-    }
-  });
 });

--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -17,13 +17,12 @@ import { useWindowGroupNavigation } from '../../src/hooks/useWindowGroupNavigati
 import { useActiveWindowId } from '../../src/contexts/ActiveWindowIdContext';
 import KeyboardShortcutsModal from '../../src/components/KeyboardShortcutsModal';
 import { DEFAULT_INACTIVE_THRESHOLD_MS } from '../../src/utils/inactiveDetection';
+import {
+  MANAGER_PORT_NAME,
+  type BackgroundToManagerMessage,
+  type ManagerToBackgroundMessage,
+} from '../../src/types/messages';
 import './style.css';
-
-// Define a more specific message type based on BaseMessage from the hook
-interface BackgroundMessage {
-  type: 'UPDATE_TABS' | 'BACKGROUND_INITIALIZED' | 'REQUEST_INITIAL_DATA'; // Known types
-  tabs?: chrome.tabs.Tab[]; // Make tabs optional as it's not always present
-}
 
 const getViewFromHash = (): ViewMode => {
   const hash = window.location.hash.slice(1);
@@ -61,9 +60,9 @@ const Manager = () => {
 
   // Define the message handler using useCallback to maintain reference stability
   const handleBackgroundMessage = useCallback(
-    async (message: BackgroundMessage) => {
+    async (message: BackgroundToManagerMessage) => {
       devLog(`${new Date()} - Received message from background:`, message); // Log received messages
-      if (message.type === 'UPDATE_TABS' && message.tabs) {
+      if (message.type === 'UPDATE_TABS') {
         setAllTabs(message.tabs);
         const currentWindowId = await refreshActiveWindowId();
         updateTabGroups(message.tabs, currentWindowId ?? undefined); // Use the updated tabs
@@ -89,7 +88,10 @@ const Manager = () => {
   );
 
   // Use the custom hook to manage the connection
-  const { sendMessage, isConnected } = useBackgroundConnection<BackgroundMessage>('manager', handleBackgroundMessage);
+  const { sendMessage, isConnected } = useBackgroundConnection<BackgroundToManagerMessage, ManagerToBackgroundMessage>(
+    MANAGER_PORT_NAME,
+    handleBackgroundMessage
+  );
 
   // Effect to request initial data once connected
   useEffect(() => {

--- a/src/hooks/useBackgroundConnection.ts
+++ b/src/hooks/useBackgroundConnection.ts
@@ -1,10 +1,8 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { devLog } from '../utils/devLog';
 
-// Define a generic type for messages if possible, or use a base type
-// For now, let's keep it flexible but avoid 'any' directly in the handler signature
-// if we know the structure. If not, unknown is safer than any.
-// Let's assume a base message structure for now.
+// Minimal structural constraint for port messages; concrete protocols
+// (e.g. src/types/messages.ts) are supplied via the type parameters.
 interface BaseMessage {
   type: string;
 }
@@ -20,16 +18,20 @@ const STABLE_CONNECTION_THRESHOLD = 60000;
  * Custom hook to manage a persistent connection to the background script.
  * Handles automatic reconnection on disconnect or connection errors.
  *
- * @param portName The name of the port to connect to.
+ * @typeParam TIncoming Messages received from the background script.
+ * @typeParam TOutgoing Messages sent to the background script.
  * @param portName The name of the port to connect to.
  * @param messageHandler A function to handle messages received from the background script.
  * @returns An object containing a function to send messages and the current connection status.
  */
-export const useBackgroundConnection = <T extends BaseMessage>(portName: string, messageHandler: MessageHandler<T>) => {
+export const useBackgroundConnection = <TIncoming extends BaseMessage, TOutgoing extends BaseMessage>(
+  portName: string,
+  messageHandler: MessageHandler<TIncoming>
+) => {
   const portRef = useRef<chrome.runtime.Port | null>(null);
   const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null);
   const stableConnectionTimerRef = useRef<NodeJS.Timeout | null>(null); // Timer to detect stable connections
-  const messageHandlerRef = useRef<MessageHandler<T>>(messageHandler);
+  const messageHandlerRef = useRef<MessageHandler<TIncoming>>(messageHandler);
   const attemptRef = useRef<number>(0); // Track retry attempts
   const [isConnected, setIsConnected] = useState(false); // Track connection status
 
@@ -62,8 +64,7 @@ export const useBackgroundConnection = <T extends BaseMessage>(portName: string,
         `${new Date()} - Waiting ${STABLE_CONNECTION_THRESHOLD}ms to confirm stable connection (current attempt: ${attemptRef.current})...`
       );
 
-      portRef.current.onMessage.addListener((message: T) => {
-        // Add type annotation
+      portRef.current.onMessage.addListener((message: TIncoming) => {
         // Use the ref to ensure the latest handler is called
         messageHandlerRef.current(message);
       });
@@ -112,8 +113,7 @@ export const useBackgroundConnection = <T extends BaseMessage>(portName: string,
   }, [connect]);
 
   const sendMessage = useCallback(
-    (message: T) => {
-      // Use the generic type T
+    (message: TOutgoing) => {
       if (!portRef.current) {
         console.warn(`${new Date()} - Cannot send message: Port is not connected.`);
         // Optionally, queue the message or attempt to reconnect immediately

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,15 @@
+/**
+ * Message contracts shared between the background service worker and the
+ * manager page. Both sides import from this module so the protocol cannot
+ * silently drift.
+ */
+
+/** Name of the runtime port the manager page connects with. */
+export const MANAGER_PORT_NAME = 'manager';
+
+/** Messages the background script posts to the manager over the port. */
+export type BackgroundToManagerMessage =
+  { type: 'UPDATE_TABS'; tabs: chrome.tabs.Tab[] } | { type: 'BACKGROUND_INITIALIZED' };
+
+/** Messages the manager sends to the background script over the port. */
+export type ManagerToBackgroundMessage = { type: 'REQUEST_INITIAL_DATA' };

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -2,16 +2,27 @@ import { describe, it, expect } from 'vitest';
 import { extractDomain } from './url';
 
 describe('extractDomain', () => {
-  it('returns the hostname for a valid http URL', () => {
-    expect(extractDomain('http://example.com/path?query=1')).toBe('example.com');
+  // Regression anchor: callers render the result as the tab subtitle, so a
+  // change of implementation (e.g. URL.host with port, www-stripping) must
+  // surface here.
+  it('returns the hostname for a URL with path, query, and hash', () => {
+    expect(extractDomain('https://sub.example.co.jp/page?query=1#hash')).toBe('sub.example.co.jp');
   });
 
-  it('returns the hostname for a valid https URL', () => {
-    expect(extractDomain('https://sub.example.co.jp/page#hash')).toBe('sub.example.co.jp');
+  // Tabs in a tab manager routinely include chrome:// pages; document what
+  // the subtitle shows for them.
+  it('returns the host part of a chrome:// URL', () => {
+    expect(extractDomain('chrome://extensions/')).toBe('extensions');
   });
 
-  it('returns an empty string for an invalid URL string', () => {
+  // The fallback is the contract this util owns: invalid input must yield
+  // an empty string, never a throw.
+  it('returns an empty string for a string that is not a URL', () => {
     expect(extractDomain('not a url')).toBe('');
+  });
+
+  it('returns an empty string for a scheme-less domain', () => {
+    expect(extractDomain('example.com')).toBe('');
   });
 
   it('returns an empty string for an empty string', () => {


### PR DESCRIPTION
## Summary

Plan Batch 2 — kills the silent-drift risk in the background ↔ manager port protocol.

### Shared message contract (`src/types/messages.ts`)
Previously the two sides declared the protocol independently: background used bare string literals (`'UPDATE_TABS'` etc.) while the manager kept its own `BackgroundMessage` interface with an optional `tabs?` — nothing tied them together. Now both import discriminated unions from one module, plus the `MANAGER_PORT_NAME` constant (was a magic string on both sides).

### `useBackgroundConnection`: split generics
One `T` used to cover both directions, which is why the manager's message type had to blur `tabs` as optional and include its own outgoing type. Now `<TIncoming, TOutgoing>` are separate; `message.type === 'UPDATE_TABS'` narrows `tabs` to non-optional `chrome.tabs.Tab[]`.

### Dead code: `closeTab` runtime listener removed
`chrome.runtime.onMessage` handler for `{action: 'closeTab'}` had **no sender anywhere** in the codebase — leftover from the pre-port implementation (a94176b); components call `chrome.tabs.remove` directly. No `externally_connectable` is configured, so nothing external can send it either.

### Test hygiene: `url.test.ts`
Reworked per review discussion — dropped the duplicated platform-behavior cases (http vs https) in favor of the contract this util owns: invalid input → `''` (never throws), scheme-less input, `chrome://` host extraction, and one regression anchor for the happy path.

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` 202 tests ✅ / `prettier --check` ✅ / `npm run build` ✅
- **E2E: 47/47 passed (38s)** — full suite, exercises the port protocol end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)