### PR TITLE
refactor: type dnd-kit data payloads via shared SortableTabData

### DIFF
--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -12,6 +12,7 @@ import FaviconImage from './FaviconImage';
 import { getTabGroupBorderColorClass } from '../utils/tabGroupColors';
 import { getTabIdsInRangeForWindow } from '../utils/dragSelection';
 import { extractDomain } from '../utils/url';
+import type { SortableTabData } from '../types/dnd';
 
 interface TabItemProps {
   tab: chrome.tabs.Tab;
@@ -64,7 +65,7 @@ const TabItem = ({ tab, isFiltered = false, index, windowId, tabs }: TabItemProp
         selectedItems: Array.from(dragSelectedTabIds),
         isSelected: dragSelectedTabIds.has(tab.id!),
         index,
-      },
+      } satisfies SortableTabData,
     });
 
   const style = {

--- a/src/components/WindowGroup.tsx
+++ b/src/components/WindowGroup.tsx
@@ -6,6 +6,7 @@ import WindowActions from './WindowActions';
 import { useWindowGroupContext } from '../contexts/WindowGroupContext';
 import { useDeletionState } from '../contexts/DeletionStateContext';
 import { toggleAllWindowGroupCollapses } from '../utils/windowGroupCollapse';
+import type { WindowGroupDropData } from '../types/dnd';
 
 interface WindowGroupProps {
   tabGroup: {
@@ -25,7 +26,7 @@ const WindowGroup = ({ tabGroup, isFiltered = false, overId, dropPosition, overW
   // Register as a drop zone for cross-window drag-and-drop
   const { setNodeRef } = useDroppable({
     id: `window-${tabGroup.windowId}`,
-    data: { windowId: tabGroup.windowId, type: 'window-group' },
+    data: { windowId: tabGroup.windowId, type: 'window-group' } satisfies WindowGroupDropData,
   });
 
   const handleCollapseClick = useCallback((event: React.MouseEvent<HTMLInputElement>) => {

--- a/src/components/WindowGroupList.tsx
+++ b/src/components/WindowGroupList.tsx
@@ -21,6 +21,7 @@ import { useToast } from './ToastProvider';
 import Alert from './Alert';
 import { useDragSelectionContext } from '../contexts/DragSelectionContext';
 import { identifyGroupsToPreserve } from '../utils/tabGroupPreservation';
+import { getSortableTabData, getWindowGroupDropData } from '../types/dnd';
 
 interface WindowGroupListProps {
   filteredTabGroups: { windowId: number; tabs: chrome.tabs.Tab[]; windowGroupNumber: number }[];
@@ -99,7 +100,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
 
   // Handle drag start to track active item for DragOverlay
   const handleDragStart = (event: DragStartEvent) => {
-    const newActiveId = event.active.id as number;
+    const newActiveId = Number(event.active.id);
     const activeTab = allTabs.find(t => t.id === newActiveId);
     sourceWindowIdRef.current = activeTab?.windowId ?? null;
     setActiveId(newActiveId);
@@ -111,7 +112,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
 
     if (over) {
       // Window group droppable (collapsed group or empty area) — no tab-level indicator
-      if (over.data.current?.type === 'window-group') {
+      if (getWindowGroupDropData(over)) {
         setOverId(null);
         return;
       }
@@ -120,7 +121,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
       const overTab = allTabs.find(t => t.id === over.id);
 
       if (activeTab && overTab) {
-        setOverId(over.id as number);
+        setOverId(Number(over.id));
 
         if (activeTab.windowId === overTab.windowId) {
           // Same window: direction based on index comparison
@@ -151,12 +152,12 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
     if (!activeTab) return;
 
     // Determine target window ID based on drop target type
-    const isWindowGroupDrop = over.data.current?.type === 'window-group';
+    const windowGroupDrop = getWindowGroupDropData(over);
     let targetWindowId: number;
 
-    if (isWindowGroupDrop) {
+    if (windowGroupDrop) {
       // Dropped on a window group container (e.g., collapsed group header)
-      targetWindowId = over.data.current!.windowId as number;
+      targetWindowId = windowGroupDrop.windowId;
     } else {
       // Dropped on a specific tab
       const overTab = allTabs.find(t => t.id === over.id);
@@ -178,8 +179,9 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
 
       try {
         // Get drag selection data from useSortable
-        const selectedItems = active.data.current?.selectedItems as number[] | undefined;
-        const isSelected = active.data.current?.isSelected as boolean;
+        const sortableData = getSortableTabData(active);
+        const selectedItems = sortableData?.selectedItems;
+        const isSelected = sortableData?.isSelected ?? false;
 
         // Determine which tabs to move
         let tabsToMove: number[];
@@ -195,7 +197,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
             .sort((a, b) => a.index - b.index)
             .map(item => item.id);
         } else {
-          tabsToMove = [active.id as number];
+          tabsToMove = [Number(active.id)];
         }
 
         // Identify tab groups to preserve (all members of a group are being moved)
@@ -303,12 +305,13 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
       // ---- Cross-window move ----
 
       // Get drag selection data from useSortable
-      const selectedItems = active.data.current?.selectedItems as number[] | undefined;
-      const isSelected = active.data.current?.isSelected as boolean;
+      const sortableData = getSortableTabData(active);
+      const selectedItems = sortableData?.selectedItems;
+      const isSelected = sortableData?.isSelected ?? false;
 
       // Calculate target index
       let targetIndex: number;
-      if (isWindowGroupDrop) {
+      if (windowGroupDrop) {
         // Dropped on window group container (collapsed group) — append to end
         targetIndex = -1;
       } else {
@@ -335,7 +338,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
           .map(item => item.id);
       } else {
         // Single-tab cross-window move
-        tabsToMove = [active.id as number];
+        tabsToMove = [Number(active.id)];
       }
 
       try {

--- a/src/types/dnd.ts
+++ b/src/types/dnd.ts
@@ -1,0 +1,33 @@
+import type { Active, Over } from '@dnd-kit/core';
+
+/**
+ * Payloads attached to dnd-kit draggable/droppable entries. dnd-kit exposes
+ * them back as untyped `data.current`; the accessors below centralize the
+ * single cast needed to read them, so call sites stay cast-free.
+ */
+
+/** Attached by TabItem's useSortable. */
+export interface SortableTabData {
+  /** Snapshot of drag-selected tab ids taken when the drag started. */
+  selectedItems: number[];
+  /** Whether the dragged tab itself is part of the drag selection. */
+  isSelected: boolean;
+  /** Index of the tab within its window group list. */
+  index: number;
+}
+
+/** Attached by WindowGroup's useDroppable (drop on the group container itself). */
+export interface WindowGroupDropData {
+  type: 'window-group';
+  windowId: number;
+}
+
+/** Reads the sortable payload of a dragged tab. */
+export const getSortableTabData = (entry: Active): SortableTabData | undefined =>
+  entry.data.current as SortableTabData | undefined;
+
+/** Returns the drop payload when the target is a window group container, undefined otherwise. */
+export const getWindowGroupDropData = (entry: Over): WindowGroupDropData | undefined => {
+  const data = entry.data.current;
+  return data?.type === 'window-group' ? (data as WindowGroupDropData) : undefined;
+};


### PR DESCRIPTION
## Summary

Plan Batch 2, second half — same drift-killing pattern as #270, applied to the DnD layer.

dnd-kit exposes `active.data.current` / `over.data.current` as untyped, so `WindowGroupList` read them through positional casts (`as number[] | undefined`, `as boolean`, `over.data.current!.windowId as number`) repeated in both the same-window and cross-window branches. Nothing tied those casts to what `TabItem` / `WindowGroup` actually attach.

### `src/types/dnd.ts`
- `SortableTabData` (attached by `TabItem`'s `useSortable`) and `WindowGroupDropData` (attached by `WindowGroup`'s `useDroppable`)
- `getSortableTabData()` / `getWindowGroupDropData()` accessors centralize the one unavoidable cast; `getWindowGroupDropData` also folds in the `type === 'window-group'` discriminant check

### Writers pinned with `satisfies`
`TabItem` and `WindowGroup` attach their payloads with `satisfies`, so renaming/removing a field now fails compilation on both ends instead of silently returning `undefined` at runtime.

### Reader cleanups in `WindowGroupList`
- 4 positional casts + 1 non-null assertion removed
- `UniqueIdentifier` (`string | number`) narrowed with `Number()` instead of `as number`

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` 202 tests ✅ / `prettier --check` ✅ / `npm run build` ✅
- **E2E: 47/47 passed (38s)** — cross-window-dnd and multi-drag specs exercise exactly the changed code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)