### PR TITLE
perf: memoize context values and derived tab data

### DIFF
--- a/entrypoints/manager/App.tsx
+++ b/entrypoints/manager/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { devLog } from '../../src/utils/devLog';
 import Header from '../../src/components/Header';
 import type { ViewMode } from '../../src/components/Header';
@@ -116,22 +116,33 @@ const Manager = () => {
   );
 
   // Map windowId to display label (Current Window / Window 1, 2, ...)
-  const windowLabels = new Map<number, string>();
-  tabGroups.forEach((group, index) => {
-    windowLabels.set(group.windowId, index === 0 ? 'Current Window' : `Window ${index}`);
-  });
+  const windowLabels = useMemo(() => {
+    const labels = new Map<number, string>();
+    tabGroups.forEach((group, index) => {
+      labels.set(group.windowId, index === 0 ? 'Current Window' : `Window ${index}`);
+    });
+    return labels;
+  }, [tabGroups]);
 
-  const filteredTabGroups = tabGroups
-    .map((group, index) => ({ ...group, windowGroupNumber: index }))
-    .map(group => ({
-      ...group,
-      tabs: group.tabs.filter(tab =>
-        ['title', 'url'].some(target => {
-          const value = (tab as chrome.tabs.Tab)[target as keyof chrome.tabs.Tab];
-          return typeof value === 'string' && value.toLowerCase().includes(searchQuery.toLowerCase());
-        })
-      ) as chrome.tabs.Tab[],
-    })) satisfies { windowId: number; tabs: chrome.tabs.Tab[]; windowGroupNumber: number }[]; // Enforce chrome.tabs.Tab[] type.
+  // Memoized so unrelated state changes (view mode, threshold) don't rebuild
+  // the groups and cascade re-renders into WindowGroupList
+  const filteredTabGroups = useMemo(
+    () =>
+      tabGroups
+        .map((group, index) => ({ ...group, windowGroupNumber: index }))
+        .map(group => ({
+          ...group,
+          tabs: group.tabs.filter(tab =>
+            ['title', 'url'].some(target => {
+              const value = (tab as chrome.tabs.Tab)[target as keyof chrome.tabs.Tab];
+              return typeof value === 'string' && value.toLowerCase().includes(searchQuery.toLowerCase());
+            })
+          ) as chrome.tabs.Tab[],
+        })) satisfies { windowId: number; tabs: chrome.tabs.Tab[]; windowGroupNumber: number }[], // Enforce chrome.tabs.Tab[] type.
+    [tabGroups, searchQuery]
+  );
+
+  const backToTabs = useCallback(() => changeView('tabs'), [changeView]);
 
   return (
     <TabFocusProvider>
@@ -150,13 +161,13 @@ const Manager = () => {
           <WindowGroupList filteredTabGroups={filteredTabGroups} isFiltered={searchQuery !== ''} />
         )}
         {viewMode === 'duplicates' && (
-          <DuplicatesView allTabs={allTabs} windowLabels={windowLabels} onBack={() => changeView('tabs')} />
+          <DuplicatesView allTabs={allTabs} windowLabels={windowLabels} onBack={backToTabs} />
         )}
         {viewMode === 'inactives' && (
           <InactivesView
             allTabs={allTabs}
             windowLabels={windowLabels}
-            onBack={() => changeView('tabs')}
+            onBack={backToTabs}
             thresholdMs={inactiveThresholdMs}
             onThresholdChange={setInactiveThresholdMs}
             onSaveAll={saveInactiveTabs}
@@ -165,7 +176,7 @@ const Manager = () => {
         {viewMode === 'saved' && (
           <SavedTabsView
             savedTabGroups={savedTabGroups}
-            onBack={() => changeView('tabs')}
+            onBack={backToTabs}
             onRestoreGroup={restoreGroup}
             onDeleteGroup={deleteGroup}
             onClearAll={clearAll}

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo, memo } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
@@ -53,6 +53,17 @@ const TabItem = ({ tab, isFiltered = false, index, windowId, tabs }: TabItemProp
   const { getGroupColor } = useTabGroupColor();
   const groupColor = getGroupColor(tab.groupId ?? chrome.tabGroups.TAB_GROUP_ID_NONE);
 
+  // Pass drag selection data for multi-drag in handleDragEnd.
+  // Memoized so the array is not re-allocated for every tab on every render.
+  const sortableData = useMemo<SortableTabData>(
+    () => ({
+      selectedItems: Array.from(dragSelectedTabIds),
+      isSelected: dragSelectedTabIds.has(tab.id!),
+      index,
+    }),
+    [dragSelectedTabIds, tab.id, index]
+  );
+
   // useSortable hook for drag-and-drop
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging, isSorting } =
     useSortable({
@@ -60,12 +71,7 @@ const TabItem = ({ tab, isFiltered = false, index, windowId, tabs }: TabItemProp
       disabled: isFiltered,
       // Disable layout animation during sorting to prevent items from moving immediately
       animateLayoutChanges: ({ isSorting }) => !isSorting,
-      // Pass drag selection data for multi-drag in handleDragEnd
-      data: {
-        selectedItems: Array.from(dragSelectedTabIds),
-        isSelected: dragSelectedTabIds.has(tab.id!),
-        index,
-      } satisfies SortableTabData,
+      data: sortableData,
     });
 
   const style = {
@@ -235,4 +241,6 @@ const TabItem = ({ tab, isFiltered = false, index, windowId, tabs }: TabItemProp
   );
 };
 
-export default TabItem;
+// Memoized: a drag-state change in WindowGroupList re-renders every window's
+// list; items whose props are unchanged can skip.
+export default memo(TabItem);

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, memo } from 'react';
 import type { KeyboardEvent } from 'react';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import TabItem from './TabItem';
@@ -83,4 +83,6 @@ const TabList = ({ tabs, isFiltered = false, overId, dropPosition }: TabListProp
   );
 };
 
-export default TabList;
+// Memoized: skips re-renders caused by unrelated window groups' drag state
+// (e.g. the cross-window ring highlight) when this list's props are unchanged.
+export default memo(TabList);

--- a/src/components/WindowGroupList.tsx
+++ b/src/components/WindowGroupList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import {
   DndContext,
   DragEndEvent,
@@ -64,8 +64,9 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
     return rectIntersection(args);
   };
 
-  // All tabs across all windows (for lookups)
-  const allTabs = filteredTabGroups.flatMap(g => g.tabs);
+  // All tabs across all windows (for lookups); memoized so drag-state renders
+  // don't rebuild it
+  const allTabs = useMemo(() => filteredTabGroups.flatMap(g => g.tabs), [filteredTabGroups]);
 
   // Store source window ID for pointer tracking (set in handleDragStart, read in useEffect)
   const sourceWindowIdRef = useRef<number | null>(null);

--- a/src/contexts/ActiveWindowIdContext.tsx
+++ b/src/contexts/ActiveWindowIdContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useContext, useCallback } from 'react';
+import React, { createContext, useState, useEffect, useContext, useCallback, useMemo } from 'react';
 
 interface ActiveWindowIdContextProps {
   activeWindowId: number | null;
@@ -21,11 +21,12 @@ export const ActiveWindowIdProvider = ({ children }: { children: React.ReactNode
     refreshActiveWindowId();
   }, [refreshActiveWindowId]);
 
-  return (
-    <ActiveWindowIdContext.Provider value={{ activeWindowId, refreshActiveWindowId }}>
-      {children}
-    </ActiveWindowIdContext.Provider>
+  const value = useMemo<ActiveWindowIdContextProps>(
+    () => ({ activeWindowId, refreshActiveWindowId }),
+    [activeWindowId, refreshActiveWindowId]
   );
+
+  return <ActiveWindowIdContext.Provider value={value}>{children}</ActiveWindowIdContext.Provider>;
 };
 
 export const useActiveWindowId = () => {

--- a/src/contexts/DragSelectionContext.tsx
+++ b/src/contexts/DragSelectionContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import * as dragSelectionUtils from '../utils/dragSelection';
 
 interface DragSelectionContextProps {
@@ -27,39 +27,59 @@ export const DragSelectionContextProvider = ({ children }: { children: React.Rea
   const [lastDragSelectedIndex, setLastDragSelectedIndex] = useState<number | null>(null);
   const [windowId, setWindowId] = useState<number | null>(null);
 
-  const addTabToDragSelection = (tabId: number, tabWindowId: number, index: number) => {
-    const result = dragSelectionUtils.addTabToDragSelection(dragSelectedTabIds, windowId, tabId, tabWindowId);
-    setDragSelectedTabIds(result.selectedIds);
-    setWindowId(result.windowId);
-    setLastDragSelectedIndex(index);
-  };
+  const addTabToDragSelection = useCallback(
+    (tabId: number, tabWindowId: number, index: number) => {
+      const result = dragSelectionUtils.addTabToDragSelection(dragSelectedTabIds, windowId, tabId, tabWindowId);
+      setDragSelectedTabIds(result.selectedIds);
+      setWindowId(result.windowId);
+      setLastDragSelectedIndex(index);
+    },
+    [dragSelectedTabIds, windowId]
+  );
 
-  const removeTabFromDragSelection = (tabId: number) => {
-    setDragSelectedTabIds(dragSelectionUtils.removeTabFromDragSelection(dragSelectedTabIds, tabId));
-  };
+  const removeTabFromDragSelection = useCallback(
+    (tabId: number) => {
+      setDragSelectedTabIds(dragSelectionUtils.removeTabFromDragSelection(dragSelectedTabIds, tabId));
+    },
+    [dragSelectedTabIds]
+  );
 
-  const clearDragSelection = () => {
+  const clearDragSelection = useCallback(() => {
     setDragSelectedTabIds(dragSelectionUtils.clearDragSelection());
     setWindowId(null);
     setLastDragSelectedIndex(null);
-  };
+  }, []);
 
-  const addTabsToDragSelection = (tabIds: number[], tabWindowId: number) => {
-    const result = dragSelectionUtils.addTabsToDragSelection(dragSelectedTabIds, windowId, tabIds, tabWindowId);
-    setDragSelectedTabIds(result.selectedIds);
-    setWindowId(result.windowId);
-  };
+  const addTabsToDragSelection = useCallback(
+    (tabIds: number[], tabWindowId: number) => {
+      const result = dragSelectionUtils.addTabsToDragSelection(dragSelectedTabIds, windowId, tabIds, tabWindowId);
+      setDragSelectedTabIds(result.selectedIds);
+      setWindowId(result.windowId);
+    },
+    [dragSelectedTabIds, windowId]
+  );
 
-  const value: DragSelectionContextProps = {
-    dragSelectedTabIds,
-    lastDragSelectedIndex,
-    windowId,
-    addTabToDragSelection,
-    removeTabFromDragSelection,
-    clearDragSelection,
-    addTabsToDragSelection,
-    setLastDragSelectedIndex,
-  };
+  const value = useMemo<DragSelectionContextProps>(
+    () => ({
+      dragSelectedTabIds,
+      lastDragSelectedIndex,
+      windowId,
+      addTabToDragSelection,
+      removeTabFromDragSelection,
+      clearDragSelection,
+      addTabsToDragSelection,
+      setLastDragSelectedIndex,
+    }),
+    [
+      dragSelectedTabIds,
+      lastDragSelectedIndex,
+      windowId,
+      addTabToDragSelection,
+      removeTabFromDragSelection,
+      clearDragSelection,
+      addTabsToDragSelection,
+    ]
+  );
 
   return <DragSelectionContext.Provider value={value}>{children}</DragSelectionContext.Provider>;
 };

--- a/src/contexts/TabFocusContext.tsx
+++ b/src/contexts/TabFocusContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, PropsWithChildren, useCallback } from 'react';
+import React, { createContext, useContext, PropsWithChildren, useCallback, useMemo } from 'react';
 import { devLog } from '../utils/devLog';
 
 interface TabFocusContextType {
@@ -21,9 +21,7 @@ export const TabFocusProvider = ({ children }: PropsWithChildren): React.ReactEl
     }
   }, []);
 
-  const value: TabFocusContextType = {
-    focusActiveTab,
-  };
+  const value = useMemo<TabFocusContextType>(() => ({ focusActiveTab }), [focusActiveTab]);
 
   return <TabFocusContext.Provider value={value}>{children}</TabFocusContext.Provider>;
 };

--- a/src/contexts/TabGroupColorContext.tsx
+++ b/src/contexts/TabGroupColorContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import { TabGroupColor } from '../types/tabGroup';
 
 interface TabGroupColorContextType {
@@ -11,14 +11,17 @@ const TabGroupColorContext = createContext<TabGroupColorContextType | undefined>
 export const TabGroupColorProvider = ({ children }: { children: ReactNode }) => {
   const [groupColorMap, setGroupColorMap] = useState<Map<number, TabGroupColor>>(new Map());
 
-  const getGroupColor = (groupId: number): TabGroupColor | null => {
-    if (groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
-      return null;
-    }
-    return groupColorMap.get(groupId) ?? null;
-  };
+  const getGroupColor = useCallback(
+    (groupId: number): TabGroupColor | null => {
+      if (groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
+        return null;
+      }
+      return groupColorMap.get(groupId) ?? null;
+    },
+    [groupColorMap]
+  );
 
-  const updateGroupColors = async (tabs: chrome.tabs.Tab[]) => {
+  const updateGroupColors = useCallback(async (tabs: chrome.tabs.Tab[]) => {
     // Extract unique group IDs from tabs
     const groupIds = new Set<number>();
     tabs.forEach(tab => {
@@ -41,13 +44,14 @@ export const TabGroupColorProvider = ({ children }: { children: ReactNode }) => 
     );
 
     setGroupColorMap(newColorMap);
-  };
+  }, []);
 
-  return (
-    <TabGroupColorContext.Provider value={{ getGroupColor, updateGroupColors }}>
-      {children}
-    </TabGroupColorContext.Provider>
+  const value = useMemo<TabGroupColorContextType>(
+    () => ({ getGroupColor, updateGroupColors }),
+    [getGroupColor, updateGroupColors]
   );
+
+  return <TabGroupColorContext.Provider value={value}>{children}</TabGroupColorContext.Provider>;
 };
 
 export const useTabGroupColor = () => {

--- a/src/contexts/TabGroupContext.tsx
+++ b/src/contexts/TabGroupContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useCallback, useContext } from 'react';
+import React, { createContext, useState, useCallback, useContext, useMemo } from 'react';
 
 interface TabGroup {
   windowId: number;
@@ -11,6 +11,26 @@ interface TabGroupContextProps {
 }
 
 const TabGroupContext = createContext<TabGroupContextProps | undefined>(undefined);
+
+const sortTabGroups = (tabGroups: TabGroup[], activeWindowId: number): TabGroup[] => {
+  const activeGroup = tabGroups.find(group => group.windowId === activeWindowId);
+  if (!activeGroup) return tabGroups;
+  return [activeGroup, ...tabGroups.filter(group => group.windowId !== activeWindowId)];
+};
+
+const groupTabsByWindow = (tabs: chrome.tabs.Tab[]): TabGroup[] => {
+  const groups: { [windowId: number]: chrome.tabs.Tab[] } = {};
+  tabs.forEach(tab => {
+    if (tab.windowId) {
+      if (!groups[tab.windowId]) {
+        groups[tab.windowId] = [];
+      }
+      groups[tab.windowId].push(tab);
+    }
+  });
+
+  return Object.entries(groups).map(([windowId, tabs]) => ({ windowId: parseInt(windowId), tabs }));
+};
 
 export const TabGroupProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
   const [tabGroups, setTabGroups] = useState<TabGroup[]>([]);
@@ -25,30 +45,7 @@ export const TabGroupProvider = ({ children }: { children: React.ReactNode }): R
     }
   }, []);
 
-  const sortTabGroups = (tabGroups: TabGroup[], activeWindowId: number): TabGroup[] => {
-    const activeGroup = tabGroups.find(group => group.windowId === activeWindowId);
-    if (!activeGroup) return tabGroups;
-    return [activeGroup, ...tabGroups.filter(group => group.windowId !== activeWindowId)];
-  };
-
-  const groupTabsByWindow = (tabs: chrome.tabs.Tab[]): TabGroup[] => {
-    const groups: { [windowId: number]: chrome.tabs.Tab[] } = {};
-    tabs.forEach(tab => {
-      if (tab.windowId) {
-        if (!groups[tab.windowId]) {
-          groups[tab.windowId] = [];
-        }
-        groups[tab.windowId].push(tab);
-      }
-    });
-
-    return Object.entries(groups).map(([windowId, tabs]) => ({ windowId: parseInt(windowId), tabs }));
-  };
-
-  const value: TabGroupContextProps = {
-    tabGroups,
-    updateTabGroups,
-  };
+  const value = useMemo<TabGroupContextProps>(() => ({ tabGroups, updateTabGroups }), [tabGroups, updateTabGroups]);
 
   return <TabGroupContext.Provider value={value}>{children}</TabGroupContext.Provider>;
 };

--- a/src/contexts/TabSelectionContext.tsx
+++ b/src/contexts/TabSelectionContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
 
 interface TabSelectionContextProps {
   selectedTabIds: Set<number>;
@@ -27,43 +27,43 @@ export const TabSelectionContextProvider = ({ children }: { children: React.Reac
   const [selectedTabIds, setSelectedTabIds] = useState<Set<number>>(new Set());
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
 
-  const addTabToSelection = (tabId: number) => {
+  const addTabToSelection = useCallback((tabId: number) => {
     setSelectedTabIds(prev => {
       const newSet = new Set(prev);
       newSet.add(tabId);
       return newSet;
     });
-  };
+  }, []);
 
-  const removeTabFromSelection = (tabId: number) => {
+  const removeTabFromSelection = useCallback((tabId: number) => {
     setSelectedTabIds(prev => {
       const newSet = new Set(prev);
       newSet.delete(tabId);
       return newSet;
     });
-  };
+  }, []);
 
-  const clearSelection = () => {
+  const clearSelection = useCallback(() => {
     setSelectedTabIds(new Set());
-  };
+  }, []);
 
-  const addTabsToSelection = (tabIds: number[]) => {
+  const addTabsToSelection = useCallback((tabIds: number[]) => {
     setSelectedTabIds(prev => {
       const newSet = new Set(prev);
       tabIds.forEach(id => newSet.add(id));
       return newSet;
     });
-  };
+  }, []);
 
-  const removeTabsFromSelection = (tabIds: number[]) => {
+  const removeTabsFromSelection = useCallback((tabIds: number[]) => {
     setSelectedTabIds(prev => {
       const newSet = new Set(prev);
       tabIds.forEach(id => newSet.delete(id));
       return newSet;
     });
-  };
+  }, []);
 
-  const syncWithExistingTabs = (existingTabIds: number[]) => {
+  const syncWithExistingTabs = useCallback((existingTabIds: number[]) => {
     setSelectedTabIds(prev => {
       const existingSet = new Set(existingTabIds);
       const newSet = new Set<number>();
@@ -74,24 +74,37 @@ export const TabSelectionContextProvider = ({ children }: { children: React.Reac
       });
       return newSet;
     });
-  };
+  }, []);
 
-  const getSelectedTabIdsArray = (): number[] => {
+  const getSelectedTabIdsArray = useCallback((): number[] => {
     return Array.from(selectedTabIds);
-  };
+  }, [selectedTabIds]);
 
-  const value: TabSelectionContextProps = {
-    selectedTabIds,
-    lastSelectedIndex,
-    addTabToSelection,
-    removeTabFromSelection,
-    clearSelection,
-    addTabsToSelection,
-    removeTabsFromSelection,
-    syncWithExistingTabs,
-    setLastSelectedIndex,
-    getSelectedTabIdsArray,
-  };
+  const value = useMemo<TabSelectionContextProps>(
+    () => ({
+      selectedTabIds,
+      lastSelectedIndex,
+      addTabToSelection,
+      removeTabFromSelection,
+      clearSelection,
+      addTabsToSelection,
+      removeTabsFromSelection,
+      syncWithExistingTabs,
+      setLastSelectedIndex,
+      getSelectedTabIdsArray,
+    }),
+    [
+      selectedTabIds,
+      lastSelectedIndex,
+      addTabToSelection,
+      removeTabFromSelection,
+      clearSelection,
+      addTabsToSelection,
+      removeTabsFromSelection,
+      syncWithExistingTabs,
+      getSelectedTabIdsArray,
+    ]
+  );
 
   return <TabSelectionContext.Provider value={value}>{children}</TabSelectionContext.Provider>;
 };


### PR DESCRIPTION
## Summary

Plan Batch 3a (runs in parallel with the view-component extraction branch — file sets are disjoint).

Every context provider handed out a fresh `value` object on each render, so any parent re-render — and `UPDATE_TABS` arrives after every 50ms-debounced tab event — cascaded through **all** context consumers whether or not their data changed.

### Providers (all six)
- `useMemo` on every context `value`; `useCallback` on plain handler functions
- `TabGroupColorContext` was the worst offender: both `getGroupColor` and `updateGroupColors` were recreated per render, so every `TabItem` calling `getGroupColor` saw a new function identity each time
- `TabGroupContext`: pure `groupTabsByWindow` / `sortTabGroups` hoisted to module scope

### Derived data
- Manager `App`: `windowLabels` (new `Map` per render) and `filteredTabGroups` (double `.map` per render) now `useMemo`'d on `[tabGroups, searchQuery]`; three inline `onBack` closures replaced by one stable `backToTabs`
- `WindowGroupList`: `allTabs` flatMap memoized (was rebuilt on every drag-state change)
- `TabItem`: `useSortable` data payload memoized — `Array.from(dragSelectedTabIds)` used to allocate per tab per render

### React.memo (ordering matters)
`TabItem` / `TabList` are wrapped in `React.memo` **after** the above made their props identity-stable — memo before stabilization would have been a no-op. During a drag, window groups whose props didn't change now skip re-rendering entirely.

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` 202 tests ✅ / `prettier --check` ✅ / `npm run build` ✅
- **E2E: 47/47 passed (37.5s)** — DnD indicators, multi-drag, cross-window flows all exercise the memoized paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)