### PR TITLE
refactor: extract shared view components and useCloseTabs hook

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ReactNode } from 'react';
+
+interface ConfirmDialogProps {
+  title: string;
+  message: ReactNode;
+  confirmLabel: string;
+  onConfirm: () => void;
+}
+
+// Reusable daisyUI confirmation modal. Open it via the forwarded ref: ref.current?.showModal().
+// ESC and backdrop clicks close it through the native <form method="dialog"> pattern.
+const ConfirmDialog = forwardRef<HTMLDialogElement, ConfirmDialogProps>(
+  ({ title, message, confirmLabel, onConfirm }, ref) => {
+    return (
+      <dialog ref={ref} className="modal">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg">{title}</h3>
+          <p className="py-4 text-base-content/70">{message}</p>
+          <div className="modal-action">
+            <form method="dialog" className="flex gap-2">
+              <button className="btn btn-sm">Cancel</button>
+              <button className="btn btn-sm btn-error" onClick={onConfirm}>
+                {confirmLabel}
+              </button>
+            </form>
+          </div>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
+    );
+  }
+);
+
+ConfirmDialog.displayName = 'ConfirmDialog';
+
+export default ConfirmDialog;

--- a/src/components/DuplicatesView.tsx
+++ b/src/components/DuplicatesView.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { useDeletionState } from '../contexts/DeletionStateContext';
 import { useTabFocusContext } from '../contexts/TabFocusContext';
-import { useToast } from './ToastProvider';
-import Alert from './Alert';
+import { useCloseTabs } from '../hooks/useCloseTabs';
+import ViewHeader from './ViewHeader';
+import EmptyState from './EmptyState';
 import FaviconImage from './FaviconImage';
 import {
   findDuplicateTabs,
@@ -11,6 +11,7 @@ import {
   type DuplicateMatchMode,
 } from '../utils/duplicateDetection';
 import { extractDomain } from '../utils/url';
+import { focusWindow } from '../utils/windowActions';
 
 interface DuplicatesViewProps {
   allTabs: chrome.tabs.Tab[];
@@ -20,9 +21,8 @@ interface DuplicatesViewProps {
 
 const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) => {
   const [matchMode, setMatchMode] = useState<DuplicateMatchMode>('normalized');
-  const { setDeletingState } = useDeletionState();
   const { focusActiveTab } = useTabFocusContext();
-  const { showToast } = useToast();
+  const { closeTabs } = useCloseTabs();
 
   const duplicates = findDuplicateTabs(allTabs, matchMode);
   const duplicateCount = countDuplicateTabs(duplicates);
@@ -30,14 +30,10 @@ const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) 
   const handleCloseGroupDuplicates = async (groupTabs: chrome.tabs.Tab[]) => {
     const toClose = getTabsToClose(groupTabs);
     const ids = toClose.map(t => t.id!);
-    ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
-    try {
-      await chrome.tabs.remove(ids);
-      showToast(<Alert message={`Closed ${ids.length} duplicate tab(s).`} variant="success" />);
-    } catch (error) {
-      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(<Alert message={`Failed to close tabs: ${error instanceof Error ? error.message : String(error)}`} />);
-    }
+    await closeTabs(ids, {
+      successMessage: `Closed ${ids.length} duplicate tab(s).`,
+      errorMessage: 'Failed to close tabs',
+    });
   };
 
   const handleCloseAllDuplicates = async () => {
@@ -46,32 +42,15 @@ const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) 
       const toClose = getTabsToClose(groupTabs);
       allToClose.push(...toClose.map(t => t.id!));
     }
-    allToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
-    try {
-      await chrome.tabs.remove(allToClose);
-      showToast(<Alert message={`Closed ${allToClose.length} duplicate tab(s).`} variant="success" />);
-    } catch (error) {
-      allToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(<Alert message={`Failed to close tabs: ${error instanceof Error ? error.message : String(error)}`} />);
-    }
+    await closeTabs(allToClose, {
+      successMessage: `Closed ${allToClose.length} duplicate tab(s).`,
+      errorMessage: 'Failed to close tabs',
+    });
   };
 
   return (
     <div className="mt-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <div className="flex items-center gap-3 shrink-0">
-          <button className="btn btn-ghost btn-sm" onClick={onBack}>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
-              <path
-                fillRule="evenodd"
-                d="M14 8a.75.75 0 0 1-.75.75H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 7.25h8.69A.75.75 0 0 1 14 8Z"
-                clipRule="evenodd"
-              />
-            </svg>
-            Back
-          </button>
-          <h2 className="text-lg font-bold whitespace-nowrap">Duplicate Tabs</h2>
-        </div>
+      <ViewHeader title="Duplicate Tabs" onBack={onBack}>
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
             <div
@@ -101,17 +80,17 @@ const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) 
             </button>
           )}
         </div>
-      </div>
+      </ViewHeader>
 
       {duplicates.size === 0 ? (
-        <div className="text-center py-16 text-base-content/60">
-          <p className="text-lg">No duplicate tabs found.</p>
-          <p className="text-sm mt-2">
-            {matchMode === 'normalized'
+        <EmptyState
+          title="No duplicate tabs found."
+          hint={
+            matchMode === 'normalized'
               ? 'Try switching to Title mode to catch more duplicates.'
-              : 'All your tabs have unique titles per domain.'}
-          </p>
-        </div>
+              : 'All your tabs have unique titles per domain.'
+          }
+        />
       ) : (
         <div className="space-y-4">
           {Array.from(duplicates.entries()).map(([url, groupTabs]) => (
@@ -162,7 +141,7 @@ const DuplicatesView = ({ allTabs, windowLabels, onBack }: DuplicatesViewProps) 
                             <button
                               type="button"
                               className="link link-hover cursor-pointer"
-                              onClick={() => chrome.windows.update(tab.windowId, { focused: true })}
+                              onClick={() => focusWindow(tab.windowId)}
                             >
                               {windowLabels.get(tab.windowId) ?? `W${tab.windowId}`}
                             </button>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  hint?: ReactNode;
+}
+
+const EmptyState = ({ title, hint }: EmptyStateProps) => {
+  return (
+    <div className="text-center py-16 text-base-content/60">
+      <p className="text-lg">{title}</p>
+      {hint && <p className="text-sm mt-2">{hint}</p>}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,7 @@ import SearchBar from './SearchBar';
 import ThemeSwitcher from './ThemeSwitcher';
 import TabCountBadge from './TabCountBadge';
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
-import { useDeletionState } from '../contexts/DeletionStateContext';
-import { useToast } from '../../src/components/ToastProvider';
-import Alert from '../../src/components/Alert';
+import { useCloseTabs } from '../hooks/useCloseTabs';
 import { useTotalTabCount } from '../hooks/useTotalTabCount';
 import { findDuplicateTabs, countDuplicateTabs } from '../utils/duplicateDetection';
 import { findInactiveTabs } from '../utils/inactiveDetection';
@@ -34,8 +32,7 @@ const Header = ({
   savedTabGroupCount,
 }: HeaderProps) => {
   const { selectedTabIds, removeTabsFromSelection } = useTabSelectionContext();
-  const { setDeletingState } = useDeletionState();
-  const { showToast } = useToast();
+  const { closeTabs } = useCloseTabs();
   const totalTabCount = useTotalTabCount();
 
   const duplicateCount = countDuplicateTabs(findDuplicateTabs(allTabs, 'normalized'));
@@ -43,20 +40,14 @@ const Header = ({
 
   const handleCloseSelectedTabs = async () => {
     const tabsToClose = Array.from(selectedTabIds); // Convert Set to array
-    // Mark all tabs as deleting
-    tabsToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
-    try {
-      await chrome.tabs.remove(tabsToClose);
-      // Success: remove all from selection
+    const closed = await closeTabs(tabsToClose, {
+      successMessage: `Selected ${tabsToClose.length} tabs closed successfully.`,
+      errorMessage: 'Error closing tabs',
+    });
+    // On error, don't update selection - let syncWithExistingTabs handle cleanup.
+    // This prevents state inconsistency when tab removal fails.
+    if (closed) {
       removeTabsFromSelection(tabsToClose);
-      showToast(<Alert message={`Selected ${tabsToClose.length} tabs closed successfully.`} variant="success" />);
-    } catch (error) {
-      // Reset deleting state for all tabs that failed to close
-      tabsToClose.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      // On error, don't update selection - let syncWithExistingTabs handle cleanup
-      // This prevents state inconsistency when tab removal fails
-      showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);
-      console.error('Error closing tabs:', error);
     }
   };
 

--- a/src/components/InactivesView.tsx
+++ b/src/components/InactivesView.tsx
@@ -1,7 +1,10 @@
 import { useDeletionState } from '../contexts/DeletionStateContext';
 import { useTabFocusContext } from '../contexts/TabFocusContext';
 import { useToast } from './ToastProvider';
+import { useCloseTabs } from '../hooks/useCloseTabs';
 import Alert from './Alert';
+import ViewHeader from './ViewHeader';
+import EmptyState from './EmptyState';
 import FaviconImage from './FaviconImage';
 import {
   findInactiveTabs,
@@ -11,6 +14,7 @@ import {
 } from '../utils/inactiveDetection';
 import type { SavedTabGroup } from '../types/savedTabs';
 import { extractDomain } from '../utils/url';
+import { focusWindow } from '../utils/windowActions';
 
 interface InactivesViewProps {
   allTabs: chrome.tabs.Tab[];
@@ -32,34 +36,28 @@ const InactivesView = ({
   const { setDeletingState } = useDeletionState();
   const { focusActiveTab } = useTabFocusContext();
   const { showToast } = useToast();
+  const { closeTabs } = useCloseTabs();
 
   const inactiveTabs = sortByInactivity(findInactiveTabs(allTabs, thresholdMs));
 
   const handleCloseTab = async (tabId: number) => {
-    setDeletingState({ type: 'tab', id: tabId, isDeleting: true });
-    try {
-      await chrome.tabs.remove(tabId);
-      showToast(<Alert message="Closed inactive tab." variant="success" />);
-    } catch (error) {
-      setDeletingState({ type: 'tab', id: tabId, isDeleting: false });
-      showToast(<Alert message={`Failed to close tab: ${error instanceof Error ? error.message : String(error)}`} />);
-    }
+    await closeTabs([tabId], {
+      successMessage: 'Closed inactive tab.',
+      errorMessage: 'Failed to close tab',
+    });
   };
 
   const handleCloseAll = async () => {
     const ids = inactiveTabs.map(t => t.id!);
-    ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
-    try {
-      await chrome.tabs.remove(ids);
-      showToast(<Alert message={`Closed ${ids.length} inactive tab(s).`} variant="success" />);
-    } catch (error) {
-      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(<Alert message={`Failed to close tabs: ${error instanceof Error ? error.message : String(error)}`} />);
-    }
+    await closeTabs(ids, {
+      successMessage: `Closed ${ids.length} inactive tab(s).`,
+      errorMessage: 'Failed to close tabs',
+    });
   };
 
   const handleSaveAll = async () => {
     const ids = inactiveTabs.map(t => t.id!);
+    // Mark as deleting before the save so the tabs appear inert while it runs.
     ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
     let group;
     try {
@@ -69,35 +67,15 @@ const InactivesView = ({
       showToast(<Alert message={`Failed to save tabs: ${error instanceof Error ? error.message : String(error)}`} />);
       return;
     }
-    try {
-      await chrome.tabs.remove(ids);
-      showToast(<Alert message={`Saved ${group.tabs.length} tab(s) and closed.`} variant="success" />);
-    } catch (error) {
-      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(
-        <Alert
-          message={`Tabs saved but could not close them: ${error instanceof Error ? error.message : String(error)}`}
-        />
-      );
-    }
+    await closeTabs(ids, {
+      successMessage: `Saved ${group.tabs.length} tab(s) and closed.`,
+      errorMessage: 'Tabs saved but could not close them',
+    });
   };
 
   return (
     <div className="mt-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <div className="flex items-center gap-3 shrink-0">
-          <button className="btn btn-ghost btn-sm" onClick={onBack}>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
-              <path
-                fillRule="evenodd"
-                d="M14 8a.75.75 0 0 1-.75.75H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 7.25h8.69A.75.75 0 0 1 14 8Z"
-                clipRule="evenodd"
-              />
-            </svg>
-            Back
-          </button>
-          <h2 className="text-lg font-bold whitespace-nowrap">Inactive Tabs</h2>
-        </div>
+      <ViewHeader title="Inactive Tabs" onBack={onBack}>
         <div className="flex items-center gap-3">
           <select
             className="select select-sm [&>option]:[padding-inline:0]"
@@ -121,16 +99,18 @@ const InactivesView = ({
             </>
           )}
         </div>
-      </div>
+      </ViewHeader>
 
       {inactiveTabs.length === 0 ? (
-        <div className="text-center py-16 text-base-content/60">
-          <p className="text-lg">No inactive tabs found.</p>
-          <p className="text-sm mt-2">
-            All your tabs have been accessed within the last{' '}
-            {INACTIVE_THRESHOLD_PRESETS.find(p => p.value === thresholdMs)?.label ?? 'selected period'}.
-          </p>
-        </div>
+        <EmptyState
+          title="No inactive tabs found."
+          hint={
+            <>
+              All your tabs have been accessed within the last{' '}
+              {INACTIVE_THRESHOLD_PRESETS.find(p => p.value === thresholdMs)?.label ?? 'selected period'}.
+            </>
+          }
+        />
       ) : (
         <>
           <div className="stats shadow mb-4">
@@ -166,7 +146,7 @@ const InactivesView = ({
                     <button
                       type="button"
                       className="link link-hover cursor-pointer"
-                      onClick={() => chrome.windows.update(tab.windowId, { focused: true })}
+                      onClick={() => focusWindow(tab.windowId)}
                     >
                       {windowLabels.get(tab.windowId) ?? `W${tab.windowId}`}
                     </button>{' '}

--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -2,6 +2,9 @@ import { useRef, useState } from 'react';
 import type { SavedTabGroup } from '../types/savedTabs';
 import { useToast } from './ToastProvider';
 import Alert from './Alert';
+import ViewHeader from './ViewHeader';
+import EmptyState from './EmptyState';
+import ConfirmDialog from './ConfirmDialog';
 import FaviconImage from './FaviconImage';
 import { formatGroupName } from '../utils/savedTabs';
 import { extractDomain } from '../utils/url';
@@ -51,32 +54,16 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
 
   return (
     <div className="mt-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <div className="flex items-center gap-3 shrink-0">
-          <button className="btn btn-ghost btn-sm" onClick={onBack}>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
-              <path
-                fillRule="evenodd"
-                d="M14 8a.75.75 0 0 1-.75.75H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 7.25h8.69A.75.75 0 0 1 14 8Z"
-                clipRule="evenodd"
-              />
-            </svg>
-            Back
-          </button>
-          <h2 className="text-lg font-bold whitespace-nowrap">Saved Tabs</h2>
-        </div>
+      <ViewHeader title="Saved Tabs" onBack={onBack}>
         {savedTabGroups.length > 0 && (
           <button className="btn btn-sm btn-error btn-outline" onClick={() => clearAllDialogRef.current?.showModal()}>
             Clear all
           </button>
         )}
-      </div>
+      </ViewHeader>
 
       {savedTabGroups.length === 0 ? (
-        <div className="text-center py-16 text-base-content/60">
-          <p className="text-lg">No saved tabs.</p>
-          <p className="text-sm mt-2">Use &quot;Save all&quot; in Inactive Tabs to save tabs here.</p>
-        </div>
+        <EmptyState title="No saved tabs." hint={<>Use &quot;Save all&quot; in Inactive Tabs to save tabs here.</>} />
       ) : (
         <div>
           {savedTabGroups.map(group => (
@@ -129,46 +116,23 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
           ))}
         </div>
       )}
-      <dialog ref={deleteDialogRef} className="modal">
-        <div className="modal-box">
-          <h3 className="font-bold text-lg">Delete saved group?</h3>
-          <p className="py-4 text-base-content/70">This cannot be undone.</p>
-          <div className="modal-action">
-            <form method="dialog" className="flex gap-2">
-              <button className="btn btn-sm">Cancel</button>
-              <button
-                className="btn btn-sm btn-error"
-                onClick={() => {
-                  if (pendingDeleteId) handleDeleteGroup(pendingDeleteId);
-                }}
-              >
-                Delete
-              </button>
-            </form>
-          </div>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <ConfirmDialog
+        ref={deleteDialogRef}
+        title="Delete saved group?"
+        message="This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (pendingDeleteId) handleDeleteGroup(pendingDeleteId);
+        }}
+      />
 
-      <dialog ref={clearAllDialogRef} className="modal">
-        <div className="modal-box">
-          <h3 className="font-bold text-lg">Clear all saved groups?</h3>
-          <p className="py-4 text-base-content/70">This cannot be undone.</p>
-          <div className="modal-action">
-            <form method="dialog" className="flex gap-2">
-              <button className="btn btn-sm">Cancel</button>
-              <button className="btn btn-sm btn-error" onClick={handleClearAll}>
-                Clear all
-              </button>
-            </form>
-          </div>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <ConfirmDialog
+        ref={clearAllDialogRef}
+        title="Clear all saved groups?"
+        message="This cannot be undone."
+        confirmLabel="Clear all"
+        onConfirm={handleClearAll}
+      />
     </div>
   );
 };

--- a/src/components/ViewHeader.tsx
+++ b/src/components/ViewHeader.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+interface ViewHeaderProps {
+  title: string;
+  onBack: () => void;
+  children?: ReactNode;
+}
+
+const ViewHeader = ({ title, onBack, children }: ViewHeaderProps) => {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+      <div className="flex items-center gap-3 shrink-0">
+        <button className="btn btn-ghost btn-sm" onClick={onBack}>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-4">
+            <path
+              fillRule="evenodd"
+              d="M14 8a.75.75 0 0 1-.75.75H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 7.25h8.69A.75.75 0 0 1 14 8Z"
+              clipRule="evenodd"
+            />
+          </svg>
+          Back
+        </button>
+        <h2 className="text-lg font-bold whitespace-nowrap">{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default ViewHeader;

--- a/src/components/WindowActions.tsx
+++ b/src/components/WindowActions.tsx
@@ -1,8 +1,14 @@
 import { useTabSelectionContext } from '../../src/contexts/TabSelectionContext';
 import { useDeletionState } from '../contexts/DeletionStateContext';
 import { useToast } from '../../src/components/ToastProvider';
+import { useCloseTabs } from '../hooks/useCloseTabs';
 import Alert from '../../src/components/Alert';
-import { countSelectedIds, shouldBulkSelectBeChecked, shouldCloseTabsBeDisabled } from '../utils/windowActions';
+import {
+  countSelectedIds,
+  focusWindow,
+  shouldBulkSelectBeChecked,
+  shouldCloseTabsBeDisabled,
+} from '../utils/windowActions';
 
 interface WindowActionsProps {
   windowId: number;
@@ -17,9 +23,10 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
   const { selectedTabIds, addTabsToSelection, removeTabsFromSelection } = useTabSelectionContext();
   const { setDeletingState } = useDeletionState();
   const { showToast } = useToast();
+  const { closeTabs } = useCloseTabs();
 
   const handleFocusWindow = () => {
-    chrome.windows.update(windowId, { focused: true });
+    focusWindow(windowId);
   };
 
   const handleBulkSelectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -52,34 +59,27 @@ const WindowActions = ({ windowId, visibleTabs }: WindowActionsProps) => {
   };
 
   const handleCloseTabsInWindow = async () => {
-    let tabIdsInWindow: number[] = [];
-    try {
-      const results = await Promise.all(
-        Array.from(selectedTabIds).map(async tabId => {
-          try {
-            const tab = await chrome.tabs.get(tabId);
-            return tab.windowId === windowId ? tabId : null;
-          } catch (error) {
-            console.error('Error getting tab:', error);
-            return null;
-          }
-        })
-      );
+    const results = await Promise.all(
+      Array.from(selectedTabIds).map(async tabId => {
+        try {
+          const tab = await chrome.tabs.get(tabId);
+          return tab.windowId === windowId ? tabId : null;
+        } catch (error) {
+          console.error('Error getting tab:', error);
+          return null;
+        }
+      })
+    );
 
-      tabIdsInWindow = results.filter((tabId): tabId is number => tabId !== null);
+    const tabIdsInWindow = results.filter((tabId): tabId is number => tabId !== null);
 
-      // Mark tabs as deleting
-      tabIdsInWindow.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
-
-      await chrome.tabs.remove(tabIdsInWindow);
-      // Remove only the closed tabs from selection instead of clearing all
+    const closed = await closeTabs(tabIdsInWindow, {
+      successMessage: `Selected ${tabIdsInWindow.length} tabs closed successfully.`,
+      errorMessage: 'Error closing tabs',
+    });
+    // Remove only the closed tabs from selection instead of clearing all
+    if (closed) {
       removeTabsFromSelection(tabIdsInWindow);
-      showToast(<Alert message={`Selected ${tabIdsInWindow.length} tabs closed successfully.`} variant="success" />);
-    } catch (error) {
-      // Reset deleting state for all tabs that failed to close
-      tabIdsInWindow.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
-      showToast(<Alert message={`Error closing tabs: ${error instanceof Error ? error.message : String(error)}`} />);
-      console.error('Error closing tabs:', error);
     }
   };
 

--- a/src/hooks/useCloseTabs.tsx
+++ b/src/hooks/useCloseTabs.tsx
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import { useDeletionState } from '../contexts/DeletionStateContext';
+import { useToast } from '../components/ToastProvider';
+import Alert from '../components/Alert';
+
+interface CloseTabsOptions {
+  // Toast shown after the tabs are removed successfully.
+  successMessage: string;
+  // Prefix for the failure toast; the error detail is appended as `${errorMessage}: <detail>`.
+  errorMessage: string;
+}
+
+const formatError = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+// Shared "mark as deleting -> remove -> rollback on failure -> toast" cycle used across views.
+// Deliberately no `finally` reset on success: items stay inert until the next UPDATE_TABS
+// removes them. Returns true on success so call sites can run their own follow-ups.
+export const useCloseTabs = () => {
+  const { setDeletingState } = useDeletionState();
+  const { showToast } = useToast();
+
+  const closeTabs = useCallback(
+    async (ids: number[], { successMessage, errorMessage }: CloseTabsOptions): Promise<boolean> => {
+      ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: true }));
+      try {
+        await chrome.tabs.remove(ids);
+        showToast(<Alert message={successMessage} variant="success" />);
+        return true;
+      } catch (error) {
+        ids.forEach(id => setDeletingState({ type: 'tab', id, isDeleting: false }));
+        showToast(<Alert message={`${errorMessage}: ${formatError(error)}`} />);
+        console.error(`${errorMessage}:`, error);
+        return false;
+      }
+    },
+    [setDeletingState, showToast]
+  );
+
+  return { closeTabs };
+};

--- a/src/utils/windowActions.test.ts
+++ b/src/utils/windowActions.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   countSelectedIds,
   shouldBulkSelectBeChecked,
   filterTabIdsByWindow,
   shouldCloseTabsBeDisabled,
+  focusWindow,
 } from './windowActions';
 
 describe('windowActions utilities', () => {
@@ -155,6 +156,38 @@ describe('windowActions utilities', () => {
       const selectedTabIds = new Set([1, 3, 4]); // Only 1 matches
 
       expect(shouldCloseTabsBeDisabled(visibleTabIds, selectedTabIds)).toBe(false);
+    });
+  });
+
+  describe('focusWindow', () => {
+    const updateMock = vi.fn();
+
+    beforeEach(() => {
+      updateMock.mockReset();
+      vi.stubGlobal('chrome', { windows: { update: updateMock } });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it('focuses the window by ID', async () => {
+      updateMock.mockResolvedValue(undefined);
+
+      await focusWindow(42);
+
+      expect(updateMock).toHaveBeenCalledWith(42, { focused: true });
+    });
+
+    it('logs an error when the update fails', async () => {
+      const error = new Error('boom');
+      updateMock.mockRejectedValue(error);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await focusWindow(7);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Error focusing window:', error);
     });
   });
 });

--- a/src/utils/windowActions.ts
+++ b/src/utils/windowActions.ts
@@ -37,3 +37,14 @@ export const filterTabIdsByWindow = (
 export const shouldCloseTabsBeDisabled = (visibleTabIds: number[], selectedTabIds: Set<number>): boolean => {
   return countSelectedIds(visibleTabIds, selectedTabIds) === 0;
 };
+
+/**
+ * Focus a browser window by its ID, bringing it to the foreground
+ */
+export const focusWindow = async (windowId: number): Promise<void> => {
+  try {
+    await chrome.windows.update(windowId, { focused: true });
+  } catch (error) {
+    console.error('Error focusing window:', error);
+  }
+};


### PR DESCRIPTION
## Summary

Plan Batch 3b (parallel with #272 — disjoint file sets, no conflicts). The three view components (Duplicates / Inactives / SavedTabs) shared near-identical structure; this extracts the shared parts.

### New shared components
- **ViewHeader** — back button (the identical inline SVG lived in all three views) + title + right-side actions slot
- **EmptyState** — the repeated `text-center py-16` empty block, hint optional
- **ConfirmDialog** — SavedTabsView had two structurally identical daisyUI `<dialog>` blocks; now one ref-based component (`ref.current?.showModal()`, ESC/backdrop close via the native `form method="dialog"` pattern)

### useCloseTabs hook
The "mark deleting → `chrome.tabs.remove` → success toast / rollback + error toast" cycle was duplicated across 5 sites (DuplicatesView ×2, InactivesView ×2, WindowActions, Header). The hook owns only the shared cycle and returns success, so site-specific follow-ups (selection cleanup, save-then-close in `handleSaveAll`) stay at the call sites. Toast wording preserved verbatim. Deliberately no `finally` reset on success — items stay inert until the next `UPDATE_TABS` (existing convention).

### focusWindow util
`chrome.windows.update(windowId, { focused: true })` was inlined in DuplicatesView and InactivesView → now `focusWindow()` in `windowActions.ts` with tests.

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` **204 tests** ✅ (2 new for focusWindow) / `prettier --check` ✅ / `npm run build` ✅
- Visual check recommended once merged: the three views' headers/empty states should look pixel-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)