### PR TITLE
fix: add confirmation dialog before Restore all opens a new window

### DIFF
--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -19,8 +19,10 @@ interface SavedTabsViewProps {
 
 const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, onClearAll }: SavedTabsViewProps) => {
   const { showToast } = useToast();
+  const restoreDialogRef = useRef<HTMLDialogElement>(null);
   const deleteDialogRef = useRef<HTMLDialogElement>(null);
   const clearAllDialogRef = useRef<HTMLDialogElement>(null);
+  const [pendingRestoreId, setPendingRestoreId] = useState<string | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const handleRestoreGroup = async (id: string) => {
@@ -77,7 +79,13 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
               </div>
               <div className="collapse-content">
                 <div className="flex gap-2 justify-end mb-3">
-                  <button className="btn btn-sm btn-success" onClick={() => handleRestoreGroup(group.id)}>
+                  <button
+                    className="btn btn-sm btn-success"
+                    onClick={() => {
+                      setPendingRestoreId(group.id);
+                      restoreDialogRef.current?.showModal();
+                    }}
+                  >
                     Restore all
                   </button>
                   <button
@@ -116,6 +124,20 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
           ))}
         </div>
       )}
+      <ConfirmDialog
+        ref={restoreDialogRef}
+        title="Restore all tabs?"
+        message={
+          pendingRestoreId
+            ? `This opens ${savedTabGroups.find(g => g.id === pendingRestoreId)?.tabs.length ?? 0} tab(s) in a new window.`
+            : ''
+        }
+        confirmLabel="Restore"
+        onConfirm={() => {
+          if (pendingRestoreId) handleRestoreGroup(pendingRestoreId);
+        }}
+      />
+
       <ConfirmDialog
         ref={deleteDialogRef}
         title="Delete saved group?"


### PR DESCRIPTION
## Summary

While manually verifying #273, clicking **Restore all** in the Saved Tabs view immediately opened every tab in the group in a new window — no confirmation, unlike **Delete** and **Clear all**.

Traced via `git log`: the confirmation-dialog feature (`eb70d0c`) only ever covered Delete and Clear all. Restore all called `handleRestoreGroup` directly from day one. Not a regression from the ConfirmDialog extraction in #273 — that refactor just carried the pre-existing ungated behavior forward unchanged.

## Fix
Same pending-id + `ConfirmDialog` pattern already used for Delete: clicking "Restore all" now opens a confirmation stating how many tabs will open (`This opens N tab(s) in a new window.`) before calling `onRestoreGroup`.

## Verification
- `tsc` ✅ / `eslint` ✅ / `vitest run` 204 tests ✅ / `prettier --check` ✅
- Manually re-checked in `build:dev` — dialog shows correct tab count, Restore/Cancel/ESC/backdrop all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)