### PR TITLE
fix(savedTabs): filter unrestorable URLs and report partial restore counts

### DIFF
--- a/src/components/SavedTabsView.tsx
+++ b/src/components/SavedTabsView.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import type { SavedTabGroup } from '../types/savedTabs';
+import type { RestoreResult } from '../hooks/useSavedTabs';
 import { useToast } from './ToastProvider';
 import Alert from './Alert';
 import ViewHeader from './ViewHeader';
@@ -12,7 +13,7 @@ import { extractDomain } from '../utils/url';
 interface SavedTabsViewProps {
   savedTabGroups: SavedTabGroup[];
   onBack: () => void;
-  onRestoreGroup: (id: string) => Promise<void>;
+  onRestoreGroup: (id: string) => Promise<RestoreResult>;
   onDeleteGroup: (id: string) => Promise<void>;
   onClearAll: () => Promise<void>;
 }
@@ -29,8 +30,12 @@ const SavedTabsView = ({ savedTabGroups, onBack, onRestoreGroup, onDeleteGroup, 
     const group = savedTabGroups.find(g => g.id === id);
     if (!group) return;
     try {
-      await onRestoreGroup(id);
-      showToast(<Alert message={`Restored ${group.tabs.length} tab(s) in a new window.`} variant="success" />);
+      const { restoredCount, filteredCount } = await onRestoreGroup(id);
+      const message =
+        filteredCount > 0
+          ? `Restored ${restoredCount} of ${restoredCount + filteredCount} tab(s). Skipped ${filteredCount} non-restorable URL(s).`
+          : `Restored ${restoredCount} tab(s) in a new window.`;
+      showToast(<Alert message={message} variant="success" />);
     } catch (error) {
       showToast(<Alert message={`Failed to restore: ${error instanceof Error ? error.message : String(error)}`} />);
     }

--- a/src/hooks/useSavedTabs.ts
+++ b/src/hooks/useSavedTabs.ts
@@ -1,6 +1,17 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { SavedTabGroup } from '../types/savedTabs';
-import { loadSavedTabGroups, addSavedTabGroup, deleteSavedTabGroup, clearAllSavedTabGroups } from '../utils/savedTabs';
+import {
+  loadSavedTabGroups,
+  addSavedTabGroup,
+  deleteSavedTabGroup,
+  clearAllSavedTabGroups,
+  isRestorableUrl,
+} from '../utils/savedTabs';
+
+export interface RestoreResult {
+  restoredCount: number;
+  filteredCount: number;
+}
 
 export function useSavedTabs() {
   const [savedTabGroups, setSavedTabGroups] = useState<SavedTabGroup[]>([]);
@@ -16,12 +27,24 @@ export function useSavedTabs() {
   }, []);
 
   const restoreGroup = useCallback(
-    async (id: string): Promise<void> => {
+    async (id: string): Promise<RestoreResult> => {
       const group = savedTabGroups.find(g => g.id === id);
-      if (!group) return;
-      await chrome.windows.create({ url: group.tabs.map(t => t.url) });
+      if (!group) return { restoredCount: 0, filteredCount: 0 };
+
+      const restorableUrls = group.tabs.map(t => t.url).filter(isRestorableUrl);
+      const filteredCount = group.tabs.length - restorableUrls.length;
+
+      if (restorableUrls.length === 0) {
+        throw new Error(
+          `No restorable URLs in this group (${filteredCount} URL(s) are chrome://, extension pages, or otherwise not openable from an extension).`
+        );
+      }
+
+      await chrome.windows.create({ url: restorableUrls });
       await deleteSavedTabGroup(id);
       setSavedTabGroups(prev => prev.filter(g => g.id !== id));
+
+      return { restoredCount: restorableUrls.length, filteredCount };
     },
     [savedTabGroups]
   );

--- a/src/utils/savedTabs.test.ts
+++ b/src/utils/savedTabs.test.ts
@@ -6,6 +6,7 @@ import {
   addSavedTabGroup,
   deleteSavedTabGroup,
   clearAllSavedTabGroups,
+  isRestorableUrl,
 } from './savedTabs';
 import type { SavedTabGroup } from '../types/savedTabs';
 
@@ -116,6 +117,36 @@ describe('clearAllSavedTabGroups', () => {
     await saveSavedTabGroups([{ id: 'a', savedAt: 1000, tabs: [] }]);
     await clearAllSavedTabGroups();
     expect(await loadSavedTabGroups()).toEqual([]);
+  });
+});
+
+// --- isRestorableUrl (pure predicate) ---
+
+describe('isRestorableUrl', () => {
+  it.each([
+    'https://example.com',
+    'http://example.com',
+    'about:blank',
+    'file:///Users/name/file.pdf',
+    'data:text/html,hi',
+  ])('returns true for %s', url => {
+    expect(isRestorableUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'chrome://extensions/',
+    'chrome://history/',
+    'chrome-extension://abcdef/page.html',
+    'javascript:alert(1)',
+    'edge://settings/',
+    'about:preferences',
+  ])('returns false for %s', url => {
+    expect(isRestorableUrl(url)).toBe(false);
+  });
+
+  it('returns false for empty or undefined', () => {
+    expect(isRestorableUrl('')).toBe(false);
+    expect(isRestorableUrl(undefined)).toBe(false);
   });
 });
 

--- a/src/utils/savedTabs.ts
+++ b/src/utils/savedTabs.ts
@@ -50,6 +50,19 @@ export function clearAllSavedTabGroups(): Promise<void> {
   });
 }
 
+// URL schemes chrome.windows.create refuses to open from an extension context.
+// `about:blank` is a common exception — Chrome does open it in a new window.
+export function isRestorableUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  if (url === 'about:blank') return true;
+  if (url.startsWith('chrome:')) return false;
+  if (url.startsWith('chrome-extension:')) return false;
+  if (url.startsWith('javascript:')) return false;
+  if (url.startsWith('edge:')) return false;
+  if (url.startsWith('about:')) return false;
+  return true;
+}
+
 export function formatGroupName(savedAt: number): string {
   const date = new Date(savedAt);
   const month = date.toLocaleString('en-US', { month: 'short' });


### PR DESCRIPTION
## Summary
- Add `isRestorableUrl` to `savedTabs.ts` — filters out `chrome:`, `chrome-extension:`, `javascript:`, `edge:`, and non-blank `about:` schemes that `chrome.windows.create` cannot open from an extension context.
- `useSavedTabs.restoreGroup` now filters each group's URLs through this predicate before calling `chrome.windows.create`. It returns `{ restoredCount, filteredCount }` so `SavedTabsView` can report partial success accurately (`"Restored N of M tab(s). Skipped X non-restorable URL(s)."`).
- If **every** URL in a group is unrestorable, `restoreGroup` throws a specific error — the existing `SavedTabsView` catch shows a toast and the group is kept.

**Diff**: `+79 / -7` lines.

## Scenarios this fixes
- A saved group containing `chrome://extensions/` or `chrome://history/` — previously deleted the group and showed a misleading `"Restored M tab(s)"` toast even when Chrome silently ignored the `chrome://` entries.
- A group made entirely of `chrome://` URLs — previously sometimes silently "succeeded" and deleted the group with no tabs opened.
- Mixed groups — the user is now told exactly how many URLs were restored vs. skipped.

## Section 7 remainder (deferred; separate PRs)
- `version` field + runtime validation for stored data.
- Favicon `data:` URI quota mitigation (option A: filter at save time).
- Multi-manager-tab state sync via `chrome.storage.onChanged`.

Continuation of Section 7 (savedTabs storage hardening) in `~/.claude/plans/lazycluster-refactoring-improvements.md`. Sibling of PR #286.

## Test plan
- [x] `npm run compile` — no type errors
- [x] `npm run test:unit` — 220/220 passing (12 new `isRestorableUrl` cases)
- [x] `npm run fix` — no format drift
- [ ] CI to confirm
- [ ] Manual: save a group with `chrome://extensions/` mixed with `https://` URLs, Restore all, expect toast reporting the skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
