### PR TITLE
refactor(dnd): extract tabMove segment-building into pure util with tests

### DIFF
--- a/src/components/WindowGroupList.tsx
+++ b/src/components/WindowGroupList.tsx
@@ -21,6 +21,7 @@ import { useToast } from './ToastProvider';
 import Alert from './Alert';
 import { useDragSelectionContext } from '../contexts/DragSelectionContext';
 import { identifyGroupsToPreserve } from '../utils/tabGroupPreservation';
+import { buildMoveSegments } from '../utils/tabMove';
 import { getSortableTabData, getWindowGroupDropData } from '../types/dnd';
 
 interface WindowGroupListProps {
@@ -209,36 +210,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
           // chrome.tabs.move() breaking group membership.
           const preservedGroupIds = new Set(groupsToPreserve.map(g => g.groupId));
           const tabMap = new Map(windowTabs.map(t => [t.id!, t]));
-
-          // Build segments: consecutive groups and ungrouped runs
-          type MoveSegment =
-            { type: 'group'; groupId: number; tabIds: number[] } | { type: 'ungrouped'; tabIds: number[] };
-          const segments: MoveSegment[] = [];
-          let currentSeg: MoveSegment | null = null;
-
-          for (const tabId of tabsToMove) {
-            const tab = tabMap.get(tabId);
-            if (!tab) continue;
-            const gid = tab.groupId;
-            const isPreserved = gid !== -1 && gid !== undefined && preservedGroupIds.has(gid);
-
-            if (isPreserved) {
-              if (currentSeg?.type === 'group' && currentSeg.groupId === gid) {
-                currentSeg.tabIds.push(tabId);
-              } else {
-                if (currentSeg) segments.push(currentSeg);
-                currentSeg = { type: 'group', groupId: gid, tabIds: [tabId] };
-              }
-            } else {
-              if (currentSeg?.type === 'ungrouped') {
-                currentSeg.tabIds.push(tabId);
-              } else {
-                if (currentSeg) segments.push(currentSeg);
-                currentSeg = { type: 'ungrouped', tabIds: [tabId] };
-              }
-            }
-          }
-          if (currentSeg) segments.push(currentSeg);
+          const segments = buildMoveSegments(tabsToMove, tabMap, preservedGroupIds);
 
           // Step 1: Collect all segments at end of window (preserves relative order)
           for (const seg of segments) {
@@ -350,36 +322,7 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
           // Segment-based cross-window move: use chrome.tabGroups.move() for groups
           const preservedGroupIds = new Set(groupsToPreserve.map(g => g.groupId));
           const tabMap = new Map(sourceWindowTabs.map(t => [t.id!, t]));
-
-          // Build segments: consecutive groups and ungrouped runs
-          type MoveSegment =
-            { type: 'group'; groupId: number; tabIds: number[] } | { type: 'ungrouped'; tabIds: number[] };
-          const segments: MoveSegment[] = [];
-          let currentSeg: MoveSegment | null = null;
-
-          for (const tabId of tabsToMove) {
-            const tab = tabMap.get(tabId);
-            if (!tab) continue;
-            const gid = tab.groupId;
-            const isPreserved = gid !== -1 && gid !== undefined && preservedGroupIds.has(gid);
-
-            if (isPreserved) {
-              if (currentSeg?.type === 'group' && currentSeg.groupId === gid) {
-                currentSeg.tabIds.push(tabId);
-              } else {
-                if (currentSeg) segments.push(currentSeg);
-                currentSeg = { type: 'group', groupId: gid, tabIds: [tabId] };
-              }
-            } else {
-              if (currentSeg?.type === 'ungrouped') {
-                currentSeg.tabIds.push(tabId);
-              } else {
-                if (currentSeg) segments.push(currentSeg);
-                currentSeg = { type: 'ungrouped', tabIds: [tabId] };
-              }
-            }
-          }
-          if (currentSeg) segments.push(currentSeg);
+          const segments = buildMoveSegments(tabsToMove, tabMap, preservedGroupIds);
 
           // Step 1: Move all segments to target window (append to end, preserves relative order)
           for (const seg of segments) {

--- a/src/utils/tabMove.test.ts
+++ b/src/utils/tabMove.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { buildMoveSegments, type MoveSegment } from './tabMove';
+
+// Helper to create a minimal chrome.tabs.Tab. `groupId` accepts undefined so we
+// can exercise the `gid !== undefined` guard.
+function makeTab(id: number, groupId: number | undefined, index = 0): chrome.tabs.Tab {
+  return {
+    id,
+    // Cast keeps the shape faithful while permitting `undefined` for testing.
+    groupId: groupId as number,
+    index,
+    pinned: false,
+    highlighted: false,
+    windowId: 1,
+    active: false,
+    incognito: false,
+    selected: false,
+    discarded: false,
+    autoDiscardable: true,
+    frozen: false,
+  };
+}
+
+function makeTabMap(tabs: chrome.tabs.Tab[]): Map<number, chrome.tabs.Tab> {
+  return new Map(tabs.map(t => [t.id!, t]));
+}
+
+describe('buildMoveSegments', () => {
+  it('returns an empty array for an empty selection', () => {
+    const result = buildMoveSegments([], makeTabMap([]), new Set());
+    expect(result).toEqual([]);
+  });
+
+  it('produces a single ungrouped segment for one ungrouped tab', () => {
+    const tabs = [makeTab(1, -1)];
+    const result = buildMoveSegments([1], makeTabMap(tabs), new Set());
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1] }]);
+  });
+
+  it('produces a single group segment for one preserved-group tab', () => {
+    const tabs = [makeTab(1, 100)];
+    const result = buildMoveSegments([1], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([{ type: 'group', groupId: 100, tabIds: [1] }]);
+  });
+
+  it('treats a grouped tab whose group is NOT in preservedGroupIds as ungrouped', () => {
+    const tabs = [makeTab(1, 100)];
+    const result = buildMoveSegments([1], makeTabMap(tabs), new Set());
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1] }]);
+  });
+
+  it('merges consecutive tabs belonging to the SAME preserved group', () => {
+    const tabs = [makeTab(1, 100), makeTab(2, 100), makeTab(3, 100)];
+    const result = buildMoveSegments([1, 2, 3], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([{ type: 'group', groupId: 100, tabIds: [1, 2, 3] }]);
+  });
+
+  it('merges consecutive ungrouped tabs into one ungrouped segment', () => {
+    const tabs = [makeTab(1, -1), makeTab(2, -1), makeTab(3, -1)];
+    const result = buildMoveSegments([1, 2, 3], makeTabMap(tabs), new Set());
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1, 2, 3] }]);
+  });
+
+  it('opens a new segment when transitioning from a preserved group to ungrouped', () => {
+    const tabs = [makeTab(1, 100), makeTab(2, 100), makeTab(3, -1), makeTab(4, -1)];
+    const result = buildMoveSegments([1, 2, 3, 4], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'group', groupId: 100, tabIds: [1, 2] },
+      { type: 'ungrouped', tabIds: [3, 4] },
+    ]);
+  });
+
+  it('opens a new segment when transitioning from ungrouped to a preserved group', () => {
+    const tabs = [makeTab(1, -1), makeTab(2, -1), makeTab(3, 100), makeTab(4, 100)];
+    const result = buildMoveSegments([1, 2, 3, 4], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'ungrouped', tabIds: [1, 2] },
+      { type: 'group', groupId: 100, tabIds: [3, 4] },
+    ]);
+  });
+
+  it('opens a new group segment when adjacent tabs belong to DIFFERENT preserved groups', () => {
+    const tabs = [makeTab(1, 100), makeTab(2, 200)];
+    const result = buildMoveSegments([1, 2], makeTabMap(tabs), new Set([100, 200]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'group', groupId: 100, tabIds: [1] },
+      { type: 'group', groupId: 200, tabIds: [2] },
+    ]);
+  });
+
+  it('handles a mixed run: group A, ungrouped, group B → three segments', () => {
+    const tabs = [makeTab(1, 100), makeTab(2, -1), makeTab(3, 200)];
+    const result = buildMoveSegments([1, 2, 3], makeTabMap(tabs), new Set([100, 200]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'group', groupId: 100, tabIds: [1] },
+      { type: 'ungrouped', tabIds: [2] },
+      { type: 'group', groupId: 200, tabIds: [3] },
+    ]);
+  });
+
+  it('does not coalesce non-adjacent tabs of the same group across a gap of another kind', () => {
+    // Interleaved: A, B, A — never merged back into a single group segment.
+    const tabs = [makeTab(1, 100), makeTab(2, 200), makeTab(3, 100)];
+    const result = buildMoveSegments([1, 2, 3], makeTabMap(tabs), new Set([100, 200]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'group', groupId: 100, tabIds: [1] },
+      { type: 'group', groupId: 200, tabIds: [2] },
+      { type: 'group', groupId: 100, tabIds: [3] },
+    ]);
+  });
+
+  it('silently skips tab IDs missing from tabMap', () => {
+    // Tab id 2 is not in the map: it should be dropped rather than crashing.
+    const tabs = [makeTab(1, -1), makeTab(3, -1)];
+    const result = buildMoveSegments([1, 2, 3], makeTabMap(tabs), new Set());
+    // Since the skipped tab keeps the currentSeg open, 1 and 3 stay merged.
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1, 3] }]);
+  });
+
+  it('treats groupId === undefined as ungrouped', () => {
+    const tabs = [makeTab(1, undefined)];
+    const result = buildMoveSegments([1], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1] }]);
+  });
+
+  it('treats groupId === -1 as ungrouped even when preservedGroupIds contains -1', () => {
+    // Guard `gid !== -1` short-circuits before the Set lookup.
+    const tabs = [makeTab(1, -1)];
+    const result = buildMoveSegments([1], makeTabMap(tabs), new Set([-1]));
+    expect(result).toEqual<MoveSegment[]>([{ type: 'ungrouped', tabIds: [1] }]);
+  });
+
+  it('preserves the input order of tabIds (does not sort)', () => {
+    // Input order 3, 1, 2 is preserved verbatim across the resulting segments.
+    const tabs = [makeTab(1, 100), makeTab(2, -1), makeTab(3, 100)];
+    const result = buildMoveSegments([3, 1, 2], makeTabMap(tabs), new Set([100]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'group', groupId: 100, tabIds: [3, 1] },
+      { type: 'ungrouped', tabIds: [2] },
+    ]);
+  });
+
+  it('handles a large selection: two groups sandwiched around ungrouped runs', () => {
+    const tabs = [
+      makeTab(1, -1),
+      makeTab(2, 100),
+      makeTab(3, 100),
+      makeTab(4, -1),
+      makeTab(5, -1),
+      makeTab(6, 200),
+      makeTab(7, 200),
+      makeTab(8, -1),
+    ];
+    const result = buildMoveSegments([1, 2, 3, 4, 5, 6, 7, 8], makeTabMap(tabs), new Set([100, 200]));
+    expect(result).toEqual<MoveSegment[]>([
+      { type: 'ungrouped', tabIds: [1] },
+      { type: 'group', groupId: 100, tabIds: [2, 3] },
+      { type: 'ungrouped', tabIds: [4, 5] },
+      { type: 'group', groupId: 200, tabIds: [6, 7] },
+      { type: 'ungrouped', tabIds: [8] },
+    ]);
+  });
+});

--- a/src/utils/tabMove.ts
+++ b/src/utils/tabMove.ts
@@ -1,0 +1,67 @@
+// Pure segment-building helpers for tab drag-and-drop moves.
+//
+// Extracted from WindowGroupList.tsx where the exact same segment-building loop
+// existed twice — once in the same-window path and once in the cross-window
+// path. This module contains only pure functions (no chrome API calls); the
+// component still owns chrome.tabs.move() / chrome.tabGroups.move() execution.
+
+/**
+ * A single move step. A `group` segment must be moved via
+ * `chrome.tabGroups.move()` so Chrome preserves the group's title, color, and
+ * membership. An `ungrouped` segment is a run of tabs moved via
+ * `chrome.tabs.move()`.
+ */
+export type MoveSegment =
+  { type: 'group'; groupId: number; tabIds: number[] } | { type: 'ungrouped'; tabIds: number[] };
+
+/**
+ * Split an ordered list of tab IDs into consecutive move segments.
+ *
+ * Behavior (matches the previous inline implementation in WindowGroupList
+ * exactly):
+ *
+ * - Tabs whose `groupId` is in `preservedGroupIds` (and not `-1` / `undefined`)
+ *   become part of a `group` segment. Consecutive tabs belonging to the SAME
+ *   preserved group are merged into one segment. A boundary between different
+ *   preserved groups closes the current segment even if both are preserved.
+ * - All other tabs (ungrouped, or grouped but not preserved) form `ungrouped`
+ *   segments. Consecutive ungrouped tabs are merged.
+ * - Tabs missing from `tabMap` are silently skipped, matching the previous
+ *   `if (!tab) continue;` guard.
+ *
+ * The output preserves the input order of `tabIds`; no sorting is done here.
+ */
+export function buildMoveSegments(
+  tabIds: number[],
+  tabMap: Map<number, chrome.tabs.Tab>,
+  preservedGroupIds: Set<number>
+): MoveSegment[] {
+  const segments: MoveSegment[] = [];
+  let currentSeg: MoveSegment | null = null;
+
+  for (const tabId of tabIds) {
+    const tab = tabMap.get(tabId);
+    if (!tab) continue;
+    const gid = tab.groupId;
+    const isPreserved = gid !== -1 && gid !== undefined && preservedGroupIds.has(gid);
+
+    if (isPreserved) {
+      if (currentSeg?.type === 'group' && currentSeg.groupId === gid) {
+        currentSeg.tabIds.push(tabId);
+      } else {
+        if (currentSeg) segments.push(currentSeg);
+        currentSeg = { type: 'group', groupId: gid, tabIds: [tabId] };
+      }
+    } else {
+      if (currentSeg?.type === 'ungrouped') {
+        currentSeg.tabIds.push(tabId);
+      } else {
+        if (currentSeg) segments.push(currentSeg);
+        currentSeg = { type: 'ungrouped', tabIds: [tabId] };
+      }
+    }
+  }
+  if (currentSeg) segments.push(currentSeg);
+
+  return segments;
+}


### PR DESCRIPTION
## Summary

`WindowGroupList.tsx` contained the exact same 29-line segment-building loop **twice** — once in the same-window drag path (former lines 213-241) and once in the cross-window drag path (former lines 354-382). Both blocks did the same pure math: translate an ordered list of tab IDs into a `MoveSegment[]` — runs of preserved-group tabs (moved via `chrome.tabGroups.move()` to preserve title/color/membership) interleaved with runs of ungrouped tabs (moved via `chrome.tabs.move()`).

This PR extracts that pure math into `src/utils/tabMove.ts` as `buildMoveSegments()` and covers it with 16 unit tests. `chrome.tabs.move()` / `chrome.tabGroups.move()` execution stays in the component — the util is pure.

**Net change:** 60 duplicated lines removed from `WindowGroupList.tsx`, replaced by 2 call sites of the same helper. Behavior is preserved bit-for-bit; the parent plan's "almost verbatim" claim (`ほぼ逐語コピペ`) is accurate — the two blocks were, in fact, exactly identical apart from the local variable name (`windowTabs` vs `sourceWindowTabs`).

Parent plan: Section 6 PR 1 of `~/.claude/plans/lazycluster-refactoring-improvements.md`.

## What changed

- **New** `src/utils/tabMove.ts`
  - `MoveSegment` type
  - `buildMoveSegments(tabIds, tabMap, preservedGroupIds)` — pure segment-building
- **New** `src/utils/tabMove.test.ts` — 16 tests capturing the invariants:
  - empty selection → `[]`
  - single ungrouped / single preserved-group tab
  - grouped tab NOT in `preservedGroupIds` → treated as ungrouped
  - consecutive same-group tabs coalesce; adjacent DIFFERENT preserved groups do NOT
  - transitions (group ↔ ungrouped) open new segments
  - interleaved (A, B, A) → three segments (never re-merged)
  - tabs missing from `tabMap` are silently skipped (matches prior guard)
  - `groupId === undefined` → ungrouped
  - `groupId === -1` → ungrouped even when `-1` is in `preservedGroupIds`
  - input order preserved verbatim; no internal sort
  - large mixed selection (group, ungrouped, group, ungrouped, group, ungrouped)
- **Modified** `src/components/WindowGroupList.tsx` — imports `buildMoveSegments`; the two duplicate 29-line loops each collapse to a single call. Everything else — `preservedGroupIds` / `tabMap` construction, the chrome API calls, index math for the ungrouped-only branch — is unchanged.

## What is DEFERRED to Section 6 PR 2

Explicitly out of scope here per the plan; called out so reviewers know why obvious follow-ups aren't in this PR:

- Extracting `useTabDragAndDrop` hook (the drag handlers themselves)
- Extracting `TabDragOverlay` component
- Introducing `DragIndicatorContext`
- Cleaning up the two `allTabs.find(t => t.id === over.id)!` non-null assertions in the cross-window path (still at the current `WindowGroupList.tsx` lines ~292 and ~338)

## Test plan

- [x] `mise exec -- npm run compile` — TypeScript passes
- [x] `mise exec -- npm run test:unit` — 236 passed (16 new tabMove tests + 220 preexisting)
- [x] `mise exec -- npm run lint` — clean
- [x] `mise exec -- npm run build` — succeeds
- [x] `mise exec -- npm run test:e2e -- cross-window-dnd` — 11 passed
- [x] `mise exec -- npm run test:e2e -- multi-drag` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
