### PR TITLE
perf(dnd): eliminate drag-over cascade re-renders

### DIFF
--- a/src/components/TabDropIndicator.tsx
+++ b/src/components/TabDropIndicator.tsx
@@ -1,0 +1,15 @@
+import { memo } from 'react';
+import { useDropIndicator } from '../contexts/DragStateContexts';
+
+interface TabDropIndicatorProps {
+  tabId: number;
+  position: 'top' | 'bottom';
+}
+
+const TabDropIndicator = ({ tabId, position }: TabDropIndicatorProps) => {
+  const { overId, dropPosition } = useDropIndicator();
+  const active = overId === tabId && dropPosition === position;
+  return <div className={`h-0.5 bg-info transition-opacity ${active ? 'opacity-100' : 'opacity-0'}`} />;
+};
+
+export default memo(TabDropIndicator);

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -2,15 +2,14 @@ import { useRef, memo } from 'react';
 import type { KeyboardEvent } from 'react';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import TabItem from './TabItem';
+import TabDropIndicator from './TabDropIndicator';
 
 interface TabListProps {
   tabs: chrome.tabs.Tab[];
   isFiltered?: boolean;
-  overId: number | null;
-  dropPosition: 'top' | 'bottom';
 }
 
-const TabList = ({ tabs, isFiltered = false, overId, dropPosition }: TabListProps) => {
+const TabList = ({ tabs, isFiltered = false }: TabListProps) => {
   const listRef = useRef<HTMLUListElement>(null);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
@@ -63,19 +62,9 @@ const TabList = ({ tabs, isFiltered = false, overId, dropPosition }: TabListProp
       <ul ref={listRef} className="list shadow-md" onKeyDown={handleKeyDown}>
         {tabs.map((tab, index) => (
           <div key={tab.id}>
-            {/* Top drop indicator */}
-            <div
-              className={`h-0.5 bg-info transition-opacity ${
-                overId === tab.id && dropPosition === 'top' ? 'opacity-100' : 'opacity-0'
-              }`}
-            />
+            <TabDropIndicator tabId={tab.id!} position="top" />
             <TabItem tab={tab} isFiltered={isFiltered} index={index} windowId={tab.windowId!} tabs={tabs} />
-            {/* Bottom drop indicator */}
-            <div
-              className={`h-0.5 bg-info transition-opacity ${
-                overId === tab.id && dropPosition === 'bottom' ? 'opacity-100' : 'opacity-0'
-              }`}
-            />
+            <TabDropIndicator tabId={tab.id!} position="bottom" />
           </div>
         ))}
       </ul>
@@ -83,6 +72,6 @@ const TabList = ({ tabs, isFiltered = false, overId, dropPosition }: TabListProp
   );
 };
 
-// Memoized: skips re-renders caused by unrelated window groups' drag state
-// (e.g. the cross-window ring highlight) when this list's props are unchanged.
+// Memoized: TabList props no longer include drag state, so drag-over updates
+// bypass this component entirely — only the tiny TabDropIndicator consumers re-render.
 export default memo(TabList);

--- a/src/components/WindowGroup.tsx
+++ b/src/components/WindowGroup.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import WindowHeader from './WindowHeader';
 import TabList from './TabList';
 import WindowActions from './WindowActions';
 import { useWindowGroupContext } from '../contexts/WindowGroupContext';
 import { useDeletionState } from '../contexts/DeletionStateContext';
+import { useRingHighlight } from '../contexts/DragStateContexts';
 import { toggleAllWindowGroupCollapses } from '../utils/windowGroupCollapse';
 import type { WindowGroupDropData } from '../types/dnd';
 
@@ -14,51 +15,76 @@ interface WindowGroupProps {
     tabs: chrome.tabs.Tab[];
   };
   isFiltered?: boolean;
-  overId: number | null;
-  dropPosition: 'top' | 'bottom';
-  overWindowId: number | null;
 }
-const WindowGroup = ({ tabGroup, isFiltered = false, overId, dropPosition, overWindowId }: WindowGroupProps) => {
-  const { windowGroupNumber } = useWindowGroupContext();
-  const { isDeleting } = useDeletionState();
-  const isDeletingWindow = isDeleting({ type: 'window', id: tabGroup.windowId });
 
-  // Register as a drop zone for cross-window drag-and-drop
-  const { setNodeRef } = useDroppable({
-    id: `window-${tabGroup.windowId}`,
-    data: { windowId: tabGroup.windowId, type: 'window-group' } satisfies WindowGroupDropData,
-  });
+interface WindowGroupContentProps {
+  windowId: number;
+  windowGroupNumber: number;
+  isFiltered: boolean;
+  tabs: chrome.tabs.Tab[];
+  active: boolean;
+}
 
-  const handleCollapseClick = useCallback((event: React.MouseEvent<HTMLInputElement>) => {
-    if (event.altKey) {
-      // The checkbox has already toggled by the time onClick fires.
-      // Read the new state and apply it to ALL window groups.
-      const targetChecked = event.currentTarget.checked;
-      toggleAllWindowGroupCollapses(targetChecked);
-    }
-  }, []);
+const WindowGroupContent = memo(
+  ({ windowId, windowGroupNumber, isFiltered, tabs, active }: WindowGroupContentProps) => {
+    const handleCollapseClick = useCallback((event: React.MouseEvent<HTMLInputElement>) => {
+      if (event.altKey) {
+        // The checkbox has already toggled by the time onClick fires.
+        // Read the new state and apply it to ALL window groups.
+        const targetChecked = event.currentTarget.checked;
+        toggleAllWindowGroupCollapses(targetChecked);
+      }
+    }, []);
 
-  return (
-    <div ref={setNodeRef} inert={isDeletingWindow || undefined} className="inert:opacity-50">
+    return (
       <div
-        className={`collapse collapse-arrow bg-base-100 border-base-300 border rounded-none mb-4 ${overWindowId === tabGroup.windowId ? 'ring-2 ring-accent' : ''}`}
+        className={`collapse collapse-arrow bg-base-100 border-base-300 border rounded-none mb-4 ${active ? 'ring-2 ring-accent' : ''}`}
         data-window-group-number={windowGroupNumber}
-        data-window-id={tabGroup.windowId}
+        data-window-id={windowId}
       >
         <input
-          id={`window-group-collapse-${tabGroup.windowId}`}
+          id={`window-group-collapse-${windowId}`}
           type="checkbox"
           defaultChecked={true}
           onClick={handleCollapseClick}
         />
         <div className="collapse-title font-semibold">
-          <WindowHeader windowId={tabGroup.windowId} />
+          <WindowHeader windowId={windowId} />
         </div>
         <div className="collapse-content">
-          <WindowActions windowId={tabGroup.windowId} visibleTabs={tabGroup.tabs} />
-          <TabList tabs={tabGroup.tabs} isFiltered={isFiltered} overId={overId} dropPosition={dropPosition} />
+          <WindowActions windowId={windowId} visibleTabs={tabs} />
+          <TabList tabs={tabs} isFiltered={isFiltered} />
         </div>
       </div>
+    );
+  }
+);
+WindowGroupContent.displayName = 'WindowGroupContent';
+
+const WindowGroup = ({ tabGroup, isFiltered = false }: WindowGroupProps) => {
+  const overWindowId = useRingHighlight();
+  const windowGroupNumber = useWindowGroupContext();
+  const { isDeleting } = useDeletionState();
+  const isDeletingWindow = isDeleting({ type: 'window', id: tabGroup.windowId });
+  const active = overWindowId === tabGroup.windowId;
+
+  // Register as a drop zone for cross-window drag-and-drop. useDroppable
+  // subscribes to DndContext, so this outer wrapper re-renders on drag ticks —
+  // that's why the actual content is split into a memoized child.
+  const { setNodeRef } = useDroppable({
+    id: `window-${tabGroup.windowId}`,
+    data: { windowId: tabGroup.windowId, type: 'window-group' } satisfies WindowGroupDropData,
+  });
+
+  return (
+    <div ref={setNodeRef} inert={isDeletingWindow || undefined} className="inert:opacity-50">
+      <WindowGroupContent
+        windowId={tabGroup.windowId}
+        windowGroupNumber={windowGroupNumber}
+        isFiltered={isFiltered}
+        tabs={tabGroup.tabs}
+        active={active}
+      />
     </div>
   );
 };

--- a/src/components/WindowGroupList.tsx
+++ b/src/components/WindowGroupList.tsx
@@ -1,7 +1,8 @@
-import { DndContext, DragOverlay } from '@dnd-kit/core';
+import { DndContext, DragOverlay, MeasuringStrategy } from '@dnd-kit/core';
 import WindowGroup from './WindowGroup';
 import TabDragOverlay from './TabDragOverlay';
 import { WindowGroupContextProvider } from '../contexts/WindowGroupContext';
+import { DragStateProvider } from '../contexts/DragStateContexts';
 import { useTabDragAndDrop, type FilteredTabGroup } from '../hooks/useTabDragAndDrop';
 
 interface WindowGroupListProps {
@@ -32,27 +33,21 @@ const WindowGroupList = ({ filteredTabGroups, isFiltered = false }: WindowGroupL
       onDragOver={onDragOver}
       onDragEnd={onDragEnd}
       onDragCancel={onDragCancel}
+      measuring={{ droppable: { strategy: MeasuringStrategy.BeforeDragging } }}
     >
-      <div className="lg:columns-2 mt-4">
-        {filteredTabGroups
-          .filter(group => group.tabs.length > 0)
-          .map(tabGroup => (
-            <div key={tabGroup.windowId} className="break-inside-avoid-column">
-              <WindowGroupContextProvider
-                key={tabGroup.windowId}
-                value={{ windowGroupNumber: tabGroup.windowGroupNumber }}
-              >
-                <WindowGroup
-                  tabGroup={tabGroup}
-                  isFiltered={isFiltered}
-                  overId={overId}
-                  dropPosition={dropPosition}
-                  overWindowId={overWindowId}
-                />
-              </WindowGroupContextProvider>
-            </div>
-          ))}
-      </div>
+      <DragStateProvider overWindowId={overWindowId} overId={overId} dropPosition={dropPosition}>
+        <div className="lg:columns-2 mt-4">
+          {filteredTabGroups
+            .filter(group => group.tabs.length > 0)
+            .map(tabGroup => (
+              <div key={tabGroup.windowId} className="break-inside-avoid-column">
+                <WindowGroupContextProvider key={tabGroup.windowId} value={tabGroup.windowGroupNumber}>
+                  <WindowGroup tabGroup={tabGroup} isFiltered={isFiltered} />
+                </WindowGroupContextProvider>
+              </div>
+            ))}
+        </div>
+      </DragStateProvider>
 
       <DragOverlay>
         {activeTab ? <TabDragOverlay activeTab={activeTab} activeTabWindowTabs={activeTabWindowTabs} /> : null}

--- a/src/components/WindowTitle.tsx
+++ b/src/components/WindowTitle.tsx
@@ -7,7 +7,7 @@ interface WindowTitleProps {
 
 const WindowTitle = ({ windowId }: WindowTitleProps) => {
   const { activeWindowId } = useActiveWindowId();
-  const { windowGroupNumber } = useWindowGroupContext();
+  const windowGroupNumber = useWindowGroupContext();
   const title = windowId === activeWindowId ? 'Current Window' : `Window ${windowGroupNumber}`;
   return <h2 className="window-title text-lg font-semibold">{title}</h2>;
 };

--- a/src/contexts/DragStateContexts.tsx
+++ b/src/contexts/DragStateContexts.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+const RingHighlightContext = createContext<number | null>(null);
+
+interface DropIndicatorState {
+  overId: number | null;
+  dropPosition: 'top' | 'bottom';
+}
+
+const DropIndicatorContext = createContext<DropIndicatorState>({
+  overId: null,
+  dropPosition: 'bottom',
+});
+
+interface DragStateProviderProps {
+  overWindowId: number | null;
+  overId: number | null;
+  dropPosition: 'top' | 'bottom';
+  children: ReactNode;
+}
+
+export const DragStateProvider = ({ overWindowId, overId, dropPosition, children }: DragStateProviderProps) => {
+  const dropIndicatorValue = useMemo(() => ({ overId, dropPosition }), [overId, dropPosition]);
+  return (
+    <RingHighlightContext.Provider value={overWindowId}>
+      <DropIndicatorContext.Provider value={dropIndicatorValue}>{children}</DropIndicatorContext.Provider>
+    </RingHighlightContext.Provider>
+  );
+};
+
+export function useRingHighlight(): number | null {
+  return useContext(RingHighlightContext);
+}
+
+export function useDropIndicator(): DropIndicatorState {
+  return useContext(DropIndicatorContext);
+}

--- a/src/contexts/WindowGroupContext.tsx
+++ b/src/contexts/WindowGroupContext.tsx
@@ -1,17 +1,13 @@
 import { createContext, useContext } from 'react';
 
-interface WindowGroupContextProps {
-  windowGroupNumber: number;
-}
+const WindowGroupContext = createContext<number | undefined>(undefined);
 
-const WindowGroupContext = createContext<WindowGroupContextProps | undefined>(undefined);
-
-export const useWindowGroupContext = () => {
-  const context = useContext(WindowGroupContext);
-  if (!context) {
+export const useWindowGroupContext = (): number => {
+  const value = useContext(WindowGroupContext);
+  if (value === undefined) {
     throw new Error('useWindowGroupContext must be used within a WindowGroupContextProvider');
   }
-  return context;
+  return value;
 };
 
 export const WindowGroupContextProvider = WindowGroupContext.Provider;

--- a/src/hooks/useTabDragAndDrop.tsx
+++ b/src/hooks/useTabDragAndDrop.tsx
@@ -86,13 +86,18 @@ export function useTabDragAndDrop(args: { filteredTabGroups: FilteredTabGroup[] 
   // Track pointer position during drag for reliable cross-window ring highlight.
   // Uses DOM elementsFromPoint() instead of dnd-kit collision detection to avoid
   // flickering caused by rectIntersection fallback matching adjacent window groups.
+  // rAF-throttled: pointermove fires up to 60Hz and elementsFromPoint is expensive.
   useEffect(() => {
     if (activeId === null) return;
 
     const sourceWindowId = sourceWindowIdRef.current;
+    let rafId: number | null = null;
+    let lastX = 0;
+    let lastY = 0;
 
-    const handlePointerMove = (e: PointerEvent) => {
-      const elements = document.elementsFromPoint(e.clientX, e.clientY);
+    const runHitTest = () => {
+      rafId = null;
+      const elements = document.elementsFromPoint(lastX, lastY);
       const windowGroupEl = elements.find(
         (el): el is HTMLElement => el instanceof HTMLElement && 'windowId' in el.dataset
       );
@@ -104,9 +109,18 @@ export function useTabDragAndDrop(args: { filteredTabGroups: FilteredTabGroup[] 
       }
     };
 
+    const handlePointerMove = (e: PointerEvent) => {
+      lastX = e.clientX;
+      lastY = e.clientY;
+      if (rafId === null) {
+        rafId = requestAnimationFrame(runHitTest);
+      }
+    };
+
     document.addEventListener('pointermove', handlePointerMove);
     return () => {
       document.removeEventListener('pointermove', handlePointerMove);
+      if (rafId !== null) cancelAnimationFrame(rafId);
       setOverWindowId(null);
     };
   }, [activeId]);


### PR DESCRIPTION
## Summary

- Every dnd-kit dragOver tick was cascading through every WindowGroup and TabList because `overId` / `dropPosition` / `overWindowId` were drilled as props from WindowGroupList, defeating existing memoization. React Profiler under the manager tab measured 28 WindowGroup renders per 3-second drag and a 54ms worst-case commit.
- Structural root: commit 44583e2 (2026-02-15, "lift DndContext from TabList to WindowGroupList") lifted the drag state to the top of the tree to make cross-window drag possible. That lift was necessary; this PR re-isolates the fan-out so only the components that actually need each slice of drag state receive it.
- Also fixes an out-of-React hot path: the `pointermove` listener in `useTabDragAndDrop` ran `document.elementsFromPoint()` on every raw pointermove (up to 60 Hz) even when the resulting state update was a no-op (same-window drag).

## Changes

- Split drag state into two contexts (`RingHighlightContext` for `overWindowId`, `DropIndicatorContext` for `{overId, dropPosition}`) so consumers subscribe only to the slice they need.
- Extract drop indicators into memoized `TabDropIndicator`, drop `overId` / `dropPosition` from TabList props — the existing `memo(TabList)` now actually bails on drag ticks.
- Split `WindowGroup` into an outer wrapper that owns `useDroppable` (thin, still re-renders per dnd subscription tick) and a memoized `WindowGroupContent` (WindowHeader + WindowActions + TabList) that skips drag-over renders entirely.
- Change `WindowGroupContext` to hold a bare `number` instead of `{ windowGroupNumber }` so the provider value stops churning on every parent render.
- rAF-throttle the `pointermove` listener in `useTabDragAndDrop`.
- Set `MeasuringStrategy.BeforeDragging` on `DndContext` so droppable rects are measured once at drag start and cached, rather than remeasured on every dragOver. Safe here because the manager tab does not shift layout during drag.

## Profiler results (single window, ~3s drag over, 60fps budget 16.6ms)

| metric | before | after |
|---|---|---|
| WindowGroupList renders | 28 | 20 |
| WindowGroup renders | 28 (1:1 with parent, no memo) | 18 (outer only, useDroppable subscription) |
| WindowGroupContent renders (new memoed subtree) | n/a — inlined | **2** |
| TabList renders | 14 (memo defeated by props) | **2** |

The residual outer-wrapper renders are cheap (setNodeRef + a `<div>`); the previously-heavy content subtree is skipped. Chrome DevTools Performance trace also showed `Layout` self-time as a significant contributor to drag-over jitter at high tab counts — `MeasuringStrategy.BeforeDragging` cuts the layout-forcing measurement calls that dnd-kit issues per tick.

## Notes on attribution

Local manual testing across a Chrome restart cycle (~130 → 67 open tabs) made the perceived jitter disappear, so multiple factors (fewer tabs, closed DevTools console, removed instrumentation, and this PR's code fixes) all contributed. The re-render reductions above are the fixed-condition measurements. The changes should mainly matter at higher tab counts where the cascade cost scales.

## Test plan

- [x] `npm run compile` passes
- [x] `npm run test:unit` — 236 tests pass
- [x] `npm run build:dev` succeeds
- [ ] E2E full suite (CI)
- [ ] Manual: same-window reorder, cross-window drop, group preservation on cross-window drop, cross-window ring highlight appears/disappears correctly, collapsed target drop, keyboard drag Escape cancel, w+N navigation, Space multi-select, j/k keyboard nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
