### PR TITLE
test(e2e): correct keyboard-drag skip reason — cause is not established

### DIFF
--- a/e2e/keyboard-drag.spec.ts
+++ b/e2e/keyboard-drag.spec.ts
@@ -12,13 +12,13 @@ async function readTabIds(page: import('@playwright/test').Page): Promise<number
 }
 
 test.describe('Keyboard Drag E2E Tests', () => {
-  // Skipped: dnd-kit's `sortableKeyboardCoordinates` computes destination
-  // coordinates within a single SortableContext. LazyCluster renders one
-  // SortableContext per window's TabList, so ArrowDown from the first tab
-  // never resolves to a new coordinate — the drag activates but sits still
-  // and the drop is a no-op. Enabling this test requires either unifying
-  // all tabs into one SortableContext or implementing a MultipleContainers
-  // coordinateGetter; tracked as follow-up separate from the hook extraction.
+  // Skipped: fails in CI and local runs as of 2026-07 — the Enter → ArrowDown
+  // → Enter sequence leaves the tab order unchanged. The cause is NOT
+  // established: a structural dnd-kit limitation (sortableKeyboardCoordinates
+  // vs per-window SortableContexts) was first suspected, but commit 59a26c2
+  // records this exact test passing, which rules out a hard "can never work"
+  // reading. Reproduce and diagnose (flaky timing / focus handling / a real
+  // conditional regression) before re-enabling or rewriting.
   test.skip('should reorder tab via keyboard drag (Enter → ArrowDown → Enter)', async ({ page, extensionId }) => {
     await page.goto(`chrome-extension://${extensionId}/manager.html`);
     await page.locator('.group\\/tabitem').first().waitFor({ state: 'visible' });


### PR DESCRIPTION
## Summary

Comment-only change. The skip reason written in commit 7931f61 for the keyboard-drag reorder test claimed a structural dnd-kit limitation (`sortableKeyboardCoordinates` cannot cross per-window SortableContexts) as established fact. That claim does not hold up:

- Commit 59a26c2's message records this exact test **passing** after the inline-handler revert. One recorded pass rules out a hard "can never work" reading.
- The test reorders within the first window's own tab list — a single SortableContext — so a cross-context limitation would not explain the failure even if it existed.

What is actually known: the test failed with the same signature (tab order unchanged after Enter → ArrowDown ×2 → Enter) in CI run 29195597440 (initial + 2 retries) and in one local run on 2026-07-13. The cause — flaky focus/timing around drag activation vs. a conditional regression — has not been separated yet.

The comment now states the evidence and the open question instead of the refuted mechanism, so whoever picks up the follow-up starts from facts rather than a wrong lead. The test remains skipped; no behavior change.

## Test plan

- [x] `npx playwright test e2e/keyboard-drag.spec.ts` — 1 skipped, 1 passed (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
