### PR TITLE
test(e2e): unskip keyboard-drag reorder and stabilize timing

### DIFF
--- a/e2e/keyboard-drag.spec.ts
+++ b/e2e/keyboard-drag.spec.ts
@@ -12,14 +12,7 @@ async function readTabIds(page: import('@playwright/test').Page): Promise<number
 }
 
 test.describe('Keyboard Drag E2E Tests', () => {
-  // Skipped: fails in CI and local runs as of 2026-07 — the Enter → ArrowDown
-  // → Enter sequence leaves the tab order unchanged. The cause is NOT
-  // established: a structural dnd-kit limitation (sortableKeyboardCoordinates
-  // vs per-window SortableContexts) was first suspected, but commit 59a26c2
-  // records this exact test passing, which rules out a hard "can never work"
-  // reading. Reproduce and diagnose (flaky timing / focus handling / a real
-  // conditional regression) before re-enabling or rewriting.
-  test.skip('should reorder tab via keyboard drag (Enter → ArrowDown → Enter)', async ({ page, extensionId }) => {
+  test('should reorder tab via keyboard drag (Enter → ArrowDown → Enter)', async ({ page, extensionId }) => {
     await page.goto(`chrome-extension://${extensionId}/manager.html`);
     await page.locator('.group\\/tabitem').first().waitFor({ state: 'visible' });
 
@@ -33,20 +26,28 @@ test.describe('Keyboard Drag E2E Tests', () => {
     const tabIdsBefore = await readTabIds(page);
     expect(tabIdsBefore.length).toBeGreaterThanOrEqual(3);
     const originalFirstId = tabIdsBefore[0];
+    const firstItem = page.locator('.group\\/tabitem').first();
 
-    // Activate keyboard drag on first tab's handle
     const firstDragHandle = page.locator('button[aria-label="Drag to reorder"]').first();
     await firstDragHandle.focus();
     await page.keyboard.press('Enter'); // Start drag
-    await page.keyboard.press('ArrowDown'); // Move over tab 1
-    await page.keyboard.press('ArrowDown'); // Move over tab 2
+    // Wait for dnd-kit to mark the item active before firing arrow keys, so the
+    // sortableKeyboardCoordinates path has a settled DragOverlay to measure against.
+    await expect(firstItem).toHaveAttribute('aria-pressed', 'true');
+
+    // Arrow keys drive sortableKeyboardCoordinates, which reads DOM rects each
+    // press. Playwright's back-to-back keydowns can outrun that measurement,
+    // so give each press one settled frame before the next — documented
+    // exception per .claude/rules/e2e-testing.md.
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(30);
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(30);
     await page.keyboard.press('Enter'); // Drop
 
-    // Wait for the Chrome API update to propagate: first tab id changed
     await expect.poll(async () => (await readTabIds(page))[0]).not.toBe(originalFirstId);
 
     const tabIdsAfter = await readTabIds(page);
-    // Original first tab moved later in the window
     const newIndex = tabIdsAfter.indexOf(originalFirstId);
     expect(newIndex).toBeGreaterThan(0);
   });
@@ -64,12 +65,16 @@ test.describe('Keyboard Drag E2E Tests', () => {
 
     const tabIdsBefore = await readTabIds(page);
     expect(tabIdsBefore.length).toBeGreaterThanOrEqual(3);
+    const firstItem = page.locator('.group\\/tabitem').first();
 
-    // Start keyboard drag, move once, then cancel with Escape
     const firstDragHandle = page.locator('button[aria-label="Drag to reorder"]').first();
     await firstDragHandle.focus();
     await page.keyboard.press('Enter'); // Start drag
+    // Same rationale as the reorder test: confirm activation before firing
+    // arrow keys so Escape actually has an in-flight drag to cancel.
+    await expect(firstItem).toHaveAttribute('aria-pressed', 'true');
     await page.keyboard.press('ArrowDown'); // Move (preview only)
+    await page.waitForTimeout(30);
     await page.keyboard.press('Escape'); // Cancel — should trigger onDragCancel
 
     // Assert the pre-existing tab order is unchanged. Slice off any tabs

--- a/e2e/keyboard-drag.spec.ts
+++ b/e2e/keyboard-drag.spec.ts
@@ -11,6 +11,15 @@ async function readTabIds(page: import('@playwright/test').Page): Promise<number
   });
 }
 
+// Y coordinate of the currently-visible drop indicator (the .bg-info element
+// dnd-kit's over state makes opacity-100). Returns null when no drag is active.
+async function dropIndicatorY(page: import('@playwright/test').Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const el = document.querySelector('.opacity-100.bg-info');
+    return el ? Math.round((el as HTMLElement).getBoundingClientRect().top) : null;
+  });
+}
+
 test.describe('Keyboard Drag E2E Tests', () => {
   test('should reorder tab via keyboard drag (Enter → ArrowDown → Enter)', async ({ page, extensionId }) => {
     await page.goto(`chrome-extension://${extensionId}/manager.html`);
@@ -31,14 +40,16 @@ test.describe('Keyboard Drag E2E Tests', () => {
     const firstDragHandle = page.locator('button[aria-label="Drag to reorder"]').first();
     await firstDragHandle.focus();
     await page.keyboard.press('Enter'); // Start drag
-    // Wait for dnd-kit to mark the item active before firing arrow keys, so the
-    // sortableKeyboardCoordinates path has a settled DragOverlay to measure against.
+    // Signal-based: wait for dnd-kit to mark the item active before firing arrow
+    // keys, so the KeyboardSensor + sortableKeyboardCoordinates path has a
+    // settled DragOverlay to measure against.
     await expect(firstItem).toHaveAttribute('aria-pressed', 'true');
 
-    // Arrow keys drive sortableKeyboardCoordinates, which reads DOM rects each
-    // press. Playwright's back-to-back keydowns can outrun that measurement,
-    // so give each press one settled frame before the next — documented
-    // exception per .claude/rules/e2e-testing.md.
+    // The race: sortableKeyboardCoordinates needs the previous keydown fully
+    // processed before the next arrives — polling AFTER a press cannot recover
+    // a keydown that raced (nothing further fires), so we settle BEFORE each
+    // next press. This is the documented waitForTimeout exception under
+    // .claude/rules/e2e-testing.md.
     await page.keyboard.press('ArrowDown');
     await page.waitForTimeout(30);
     await page.keyboard.press('ArrowDown');
@@ -70,12 +81,18 @@ test.describe('Keyboard Drag E2E Tests', () => {
     const firstDragHandle = page.locator('button[aria-label="Drag to reorder"]').first();
     await firstDragHandle.focus();
     await page.keyboard.press('Enter'); // Start drag
-    // Same rationale as the reorder test: confirm activation before firing
-    // arrow keys so Escape actually has an in-flight drag to cancel.
     await expect(firstItem).toHaveAttribute('aria-pressed', 'true');
     await page.keyboard.press('ArrowDown'); // Move (preview only)
     await page.waitForTimeout(30);
     await page.keyboard.press('Escape'); // Cancel — should trigger onDragCancel
+
+    // Positive control for the cancel path: without these, a broken onDragCancel
+    // would still pass the "no reorder" assertion because ArrowDown alone never
+    // calls chrome.tabs.move — a hung drag looks identical to a cancelled one
+    // in tab-order terms. Instrumenting the hook at HEAD shows onDragCancel
+    // does fire in practice, so this hardens rather than uncovers a bug.
+    await expect(firstItem).not.toHaveAttribute('aria-pressed', 'true');
+    await expect.poll(() => dropIndicatorY(page)).toBeNull();
 
     // Assert the pre-existing tab order is unchanged. Slice off any tabs
     // that appear during the poll window (test environment may spawn stray


### PR DESCRIPTION
## Summary

Un-skip the keyboard-drag reorder test and fix the underlying flake by giving dnd-kit's KeyboardSensor room to breathe between synthetic key presses. Also strengthens the Escape test's cancel-path assertion.

**Root cause.** `KeyboardSensor` runs `sortableKeyboardCoordinates` on each keydown, and that helper reads DOM rects synchronously to compute the next "over" target. Playwright's back-to-back `page.keyboard.press` calls outrun the measurement — `onDragStart` fires, but the second `ArrowDown` in the reorder test's `Enter → ArrowDown → ArrowDown → Enter` burst is silently lost and the final `Enter` never reaches `onDragEnd`. Instrumenting the drag hook with `console.log` at each handler confirmed the sequence dies after one `onDragOver` at Playwright speed and completes fully when there is settle time between key presses.

**Fix (test-side).**

- After the start `Enter`, wait for `aria-pressed="true"` on the sortable item — the real signal that dnd-kit activated the drag and the `DragOverlay` is measurable.
- Between `ArrowDown` presses, `waitForTimeout(30)` so the sensor can process the previous key before the next arrives. This is the documented `waitForTimeout` exception under `.claude/rules/e2e-testing.md`.
- Escape test now asserts `aria-pressed` is removed and the drop indicator disappears after Escape — the previous assertion ("tab order unchanged") would pass whether `onDragCancel` actually fired or not, because `ArrowDown` alone never calls `chrome.tabs.move`.

**Corrections to my own earlier claims.**

- The initial PR body called the pre-fix Escape test's green run "trivially passing". That was inference, not observation. Rerunning the pre-fix Escape test with hook-side instrumentation showed `onDragCancel` fires in every run and the ArrowDown usually produces a real `onDragOver` too. The Escape test was passing for the right reason; the flake is specific to the reorder test's two-back-to-back-ArrowDown burst. The stronger assertions in the second commit are a hardening, not a bug hunt.
- I tried the reviewer's suggestion of signal-based polling (`expect.poll` on the drop indicator's Y coordinate instead of `waitForTimeout`) and it was **worse**: 4 of 10 runs failed. A raced ArrowDown is lost, not delayed — no downstream DOM change ever arrives, so the poll just times out at 5000ms. The wait has to go BEFORE the next keypress to give the sensor time to process the last one; polling AFTER cannot recover a keydown that already raced. `.claude/rules/e2e-testing.md` now records this so the next author does not repeat the experiment.

**Reconciliation with #291.** PR #291 (commit c684a8c) argued that the "structural dnd-kit limitation" story was falsified by commit 59a26c2's message recording this test passing. Re-running at 59a26c2 in this session reproduces the same failure signature, so that pass was itself a flaky pass and did not carry the evidential weight #291 assigned it. The conclusion — that the previous skip reason was wrong — still holds; the reason it was wrong is that the failure is timing-flaky, not that a structural story was refuted.

## Test plan

- [x] `mise exec -- npx playwright test e2e/keyboard-drag.spec.ts --repeat-each=5` — both tests, 10/10 pass (verified after each change)
- [x] `mise exec -- npm run compile` — clean
- [x] `mise exec -- npm run fix` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
