### PR TITLE
docs(shortcuts): document drag-selection clicks on the ⋮⋮ handle

### DIFF
--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -22,6 +22,11 @@ const KeyboardShortcutsModal = () => {
       { key: 'Space', description: 'Toggle tab selection' },
       { key: 'ESC', description: 'Return focus to tab item (from inner elements)' },
     ],
+    'Tab Drag Selection': [
+      { key: 'Cmd/Ctrl + Click ⋮⋮', description: 'Add or remove a tab from the drag selection' },
+      { key: 'Shift + Click ⋮⋮', description: 'Select a range of tabs in the same window' },
+      { key: 'Click ⋮⋮', description: 'Clear the drag selection (click any selected tab)' },
+    ],
   };
 
   return (


### PR DESCRIPTION
## What

Adds a **Tab Drag Selection** section to the keyboard shortcuts modal (`?`), documenting the three click gestures on the `⋮⋮` drag handle.

| Key label | Description |
| --- | --- |
| `Cmd/Ctrl + Click ⋮⋮` | Add or remove a tab from the drag selection |
| `Shift + Click ⋮⋮` | Select a range of tabs in the same window |
| `Click ⋮⋮` | Clear the drag selection (click any selected tab) |

## Why

The modal had no entry for drag selection at all. Its only selection-related row was `Space` → "Toggle tab selection", which is checkbox selection — a different mechanism with a different scope from drag selection.

That made the whole multi-drag feature undiscoverable, and the plain-click case is a particularly unhelpful dead end: on an **unselected** tab, `handleDragHandleClick` (`src/components/TabItem.tsx:136`) matches no branch and returns silently. So the natural way to probe an unfamiliar control — click it once — produces no feedback and no hint that modifier keys are the way in.

The key labels carry the `⋮⋮` glyph on purpose, so the modal points at the control the user can actually see rather than at an abstract "drag handle".

## What this is not

No behaviour change. `handleDragHandleClick` is untouched; this PR only adds rows to the `shortcuts` object in `KeyboardShortcutsModal.tsx`.

Making plain click *select* the first tab (instead of doing nothing) was considered and deliberately rejected — it would remove the only manual way to clear a drag selection, since `clearDragSelection` is otherwise called only from the two post-drop paths in `useTabDragAndDrop.tsx`, and there is no Escape handler for it.

## Verification

- `npm run compile` — passes (exit 0)
- `npm run fix` — no Prettier reformatting; the diff is 5 added lines and nothing else
- No unit or E2E test references this modal, so there is no test to update

Not manually exercised in a browser — the change is a static data addition rendered by existing markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
